### PR TITLE
Feature/backports collection

### DIFF
--- a/cmake/linker_script/common/common-rom.cmake
+++ b/cmake/linker_script/common/common-rom.cmake
@@ -91,6 +91,10 @@ zephyr_linker_section_configure(
   KEEP SORT NAME
 )
 
+if(CONFIG_NETWORKING)
+  zephyr_iterable_section(NAME net_l3_register KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN})
+endif()
+
 if(CONFIG_NET_SOCKETS)
   zephyr_iterable_section(NAME net_socket_register KVMA RAM_REGION GROUP RODATA_REGION SUBALIGN ${CONFIG_LINKER_ITERABLE_SUBALIGN})
 endif()

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -729,6 +729,11 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 				net_eth_carrier_on(get_iface(dev_data));
 			}
 			while ((pkt = eth_rx(dev)) != NULL) {
+				if (ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PNIO) {
+					/* NET_PRIORITY_NC = 7  /**< Network control (highest)          *1/ */
+					net_pkt_set_priority(pkt, NET_PRIORITY_NC);
+				}
+
 				iface = net_pkt_iface(pkt);
 #if defined(CONFIG_NET_DSA)
 				iface = dsa_net_recv(iface, &pkt);

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -462,11 +462,12 @@ static int phy_mii_initialize(const struct device *dev)
 
 		/* Advertise all speeds */
 		phy_mii_cfg_link(dev, LINK_HALF_10BASE_T |
-				      LINK_FULL_10BASE_T |
+				      LINK_FULL_10BASE_T /* |
 				      LINK_HALF_100BASE_T |
 				      LINK_FULL_100BASE_T |
 				      LINK_HALF_1000BASE_T |
-				      LINK_FULL_1000BASE_T);
+				      LINK_FULL_1000BASE_T */
+				      );
 
 		k_work_init_delayable(&data->monitor_work,
 					monitor_work_handler);

--- a/include/zephyr/linker/common-rom/common-rom-net.ld
+++ b/include/zephyr/linker/common-rom/common-rom-net.ld
@@ -2,6 +2,10 @@
 
 #include <zephyr/linker/iterable_sections.h>
 
+#if defined(CONFIG_NETWORKING)
+	ITERABLE_SECTION_ROM(net_l3_register, Z_LINK_ITERABLE_SUBALIGN)
+#endif
+
 #if defined(CONFIG_NET_SOCKETS)
 	ITERABLE_SECTION_ROM(net_socket_register, Z_LINK_ITERABLE_SUBALIGN)
 #endif

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -70,6 +70,7 @@ struct net_eth_addr {
 #define NET_ETH_PTYPE_IP		0x0800
 #define NET_ETH_PTYPE_IPV6		0x86dd
 #define NET_ETH_PTYPE_LLDP		0x88cc
+#define NET_ETH_PTYPE_PNIO		0x8892
 #define NET_ETH_PTYPE_PTP		0x88f7
 #define NET_ETH_PTYPE_TSN		0x22f0 /* TSN (IEEE 1722) packet */
 #define NET_ETH_PTYPE_VLAN		0x8100

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -611,9 +611,7 @@ struct ethernet_vlan {
 #if defined(CONFIG_NET_VLAN_COUNT)
 #define NET_VLAN_MAX_COUNT CONFIG_NET_VLAN_COUNT
 #else
-/* Even thou there are no VLAN support, the minimum count must be set to 1.
- */
-#define NET_VLAN_MAX_COUNT 1
+#define NET_VLAN_MAX_COUNT 0
 #endif
 
 /** @endcond */
@@ -674,7 +672,14 @@ struct ethernet_context {
 	struct net_if *iface;
 
 #if defined(CONFIG_NET_LLDP)
-	struct ethernet_lldp lldp[NET_VLAN_MAX_COUNT];
+#if NET_VLAN_MAX_COUNT > 0
+#define NET_LLDP_MAX_COUNT NET_VLAN_MAX_COUNT
+#else
+#define NET_LLDP_MAX_COUNT 1
+#endif /* NET_VLAN_MAX_COUNT > 0 */
+
+	/** LLDP specific parameters */
+	struct ethernet_lldp lldp[NET_LLDP_MAX_COUNT];
 #endif
 
 	/**
@@ -981,7 +986,7 @@ int net_eth_get_hw_config(struct net_if *iface, enum ethernet_config_type type,
  *
  * @return 0 if ok, <0 if error
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 int net_eth_vlan_enable(struct net_if *iface, uint16_t tag);
 #else
 static inline int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
@@ -1001,7 +1006,7 @@ static inline int net_eth_vlan_enable(struct net_if *iface, uint16_t tag)
  *
  * @return 0 if ok, <0 if error
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 int net_eth_vlan_disable(struct net_if *iface, uint16_t tag);
 #else
 static inline int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
@@ -1024,7 +1029,7 @@ static inline int net_eth_vlan_disable(struct net_if *iface, uint16_t tag)
  * @return VLAN tag for this interface or NET_VLAN_TAG_UNSPEC if VLAN
  * is not configured for that interface.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 uint16_t net_eth_get_vlan_tag(struct net_if *iface);
 #else
 static inline uint16_t net_eth_get_vlan_tag(struct net_if *iface)
@@ -1066,7 +1071,7 @@ struct net_if *net_eth_get_vlan_iface(struct net_if *iface, uint16_t tag)
  * @return Network interface related to this tag or NULL if no such interface
  * exists.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 struct net_if *net_eth_get_vlan_main(struct net_if *iface);
 #else
 static inline
@@ -1112,7 +1117,7 @@ static inline bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
  *
  * @return True if VLAN is enabled for this network interface, false if not.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 bool net_eth_get_vlan_status(struct net_if *iface);
 #else
 static inline bool net_eth_get_vlan_status(struct net_if *iface)
@@ -1130,7 +1135,7 @@ static inline bool net_eth_get_vlan_status(struct net_if *iface)
  *
  * @return True if this network interface is VLAN one, false if not.
  */
-#if defined(CONFIG_NET_VLAN)
+#if defined(CONFIG_NET_VLAN) && NET_VLAN_MAX_COUNT > 0
 bool net_eth_is_vlan_interface(struct net_if *iface);
 #else
 static inline bool net_eth_is_vlan_interface(struct net_if *iface)

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -58,47 +58,32 @@ struct net_eth_addr {
 
 #define NET_ETH_HDR(pkt) ((struct net_eth_hdr *)net_pkt_data(pkt))
 
+/* zephyr-keep-sorted-start */
+#define NET_ETH_PTYPE_ALL		0x0003 /* from linux/if_ether.h */
+#define NET_ETH_PTYPE_ARP		0x0806
 #define NET_ETH_PTYPE_CAN		0x000C /* CAN: Controller Area Network */
 #define NET_ETH_PTYPE_CANFD		0x000D /* CANFD: CAN flexible data rate*/
-#define NET_ETH_PTYPE_HDLC		0x0019 /* HDLC frames (like in PPP) */
-#define NET_ETH_PTYPE_ARP		0x0806
-#define NET_ETH_PTYPE_IP		0x0800
-#define NET_ETH_PTYPE_TSN		0x22f0 /* TSN (IEEE 1722) packet */
-#define NET_ETH_PTYPE_IPV6		0x86dd
-#define NET_ETH_PTYPE_VLAN		0x8100
-#define NET_ETH_PTYPE_PTP		0x88f7
-#define NET_ETH_PTYPE_LLDP		0x88cc
-#define NET_ETH_PTYPE_ALL               0x0003 /* from linux/if_ether.h */
-#define NET_ETH_PTYPE_ECAT		0x88a4
 #define NET_ETH_PTYPE_EAPOL		0x888e
+#define NET_ETH_PTYPE_ECAT		0x88a4
+#define NET_ETH_PTYPE_HDLC		0x0019 /* HDLC frames (like in PPP) */
 #define NET_ETH_PTYPE_IEEE802154	0x00F6 /* from linux/if_ether.h: IEEE802.15.4 frame */
+#define NET_ETH_PTYPE_IP		0x0800
+#define NET_ETH_PTYPE_IPV6		0x86dd
+#define NET_ETH_PTYPE_LLDP		0x88cc
+#define NET_ETH_PTYPE_PTP		0x88f7
+#define NET_ETH_PTYPE_TSN		0x22f0 /* TSN (IEEE 1722) packet */
+#define NET_ETH_PTYPE_VLAN		0x8100
+/* zephyr-keep-sorted-stop */
 
-#if !defined(ETH_P_ALL)
-#define ETH_P_ALL	NET_ETH_PTYPE_ALL
-#endif
-#if !defined(ETH_P_IP)
-#define ETH_P_IP	NET_ETH_PTYPE_IP
-#endif
-#if !defined(ETH_P_ARP)
-#define ETH_P_ARP	NET_ETH_PTYPE_ARP
-#endif
-#if !defined(ETH_P_IPV6)
-#define ETH_P_IPV6	NET_ETH_PTYPE_IPV6
-#endif
+/* zephyr-keep-sorted-start re(^#define) */
 #if !defined(ETH_P_8021Q)
 #define ETH_P_8021Q	NET_ETH_PTYPE_VLAN
 #endif
-#if !defined(ETH_P_TSN)
-#define ETH_P_TSN	NET_ETH_PTYPE_TSN
+#if !defined(ETH_P_ALL)
+#define ETH_P_ALL	NET_ETH_PTYPE_ALL
 #endif
-#if !defined(ETH_P_ECAT)
-#define  ETH_P_ECAT	NET_ETH_PTYPE_ECAT
-#endif
-#if !defined(ETH_P_EAPOL)
-#define ETH_P_EAPOL	NET_ETH_PTYPE_EAPOL
-#endif
-#if !defined(ETH_P_IEEE802154)
-#define  ETH_P_IEEE802154 NET_ETH_PTYPE_IEEE802154
+#if !defined(ETH_P_ARP)
+#define ETH_P_ARP	NET_ETH_PTYPE_ARP
 #endif
 #if !defined(ETH_P_CAN)
 #define ETH_P_CAN	NET_ETH_PTYPE_CAN
@@ -106,9 +91,28 @@ struct net_eth_addr {
 #if !defined(ETH_P_CANFD)
 #define ETH_P_CANFD	NET_ETH_PTYPE_CANFD
 #endif
+#if !defined(ETH_P_EAPOL)
+#define ETH_P_EAPOL	NET_ETH_PTYPE_EAPOL
+#endif
+#if !defined(ETH_P_ECAT)
+#define ETH_P_ECAT	NET_ETH_PTYPE_ECAT
+#endif
 #if !defined(ETH_P_HDLC)
 #define ETH_P_HDLC	NET_ETH_PTYPE_HDLC
 #endif
+#if !defined(ETH_P_IEEE802154)
+#define ETH_P_IEEE802154 NET_ETH_PTYPE_IEEE802154
+#endif
+#if !defined(ETH_P_IP)
+#define ETH_P_IP	NET_ETH_PTYPE_IP
+#endif
+#if !defined(ETH_P_IPV6)
+#define ETH_P_IPV6	NET_ETH_PTYPE_IPV6
+#endif
+#if !defined(ETH_P_TSN)
+#define ETH_P_TSN	NET_ETH_PTYPE_TSN
+#endif
+/* zephyr-keep-sorted-stop */
 
 /** @endcond */
 

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -1258,6 +1258,16 @@ static inline bool net_eth_is_vlan_interface(struct net_if *iface)
 	ETH_NET_DEVICE_DT_DEFINE(DT_DRV_INST(inst), __VA_ARGS__)
 
 /**
+ * @brief Ethernet L3 protocol register macro.
+ *
+ * @param name Name of the L3 protocol.
+ * @param ptype Ethernet protocol type.
+ * @param handler Handler function for this protocol type.
+ */
+#define ETH_NET_L3_REGISTER(name, ptype, handler) \
+	NET_L3_REGISTER(&NET_L2_GET_NAME(ETHERNET), name, ptype, handler)
+
+/**
  * @brief Inform ethernet L2 driver that ethernet carrier is detected.
  * This happens when cable is connected.
  *

--- a/include/zephyr/net/ethernet_vlan.h
+++ b/include/zephyr/net/ethernet_vlan.h
@@ -31,6 +31,9 @@ extern "C" {
 /** Unspecified VLAN tag value */
 #define NET_VLAN_TAG_UNSPEC 0x0fff
 
+/** VLAN ID for forwarding to the native interface (priority tagging) */
+#define NET_VLAN_TAG_PRIORITY 0x0000
+
 /**
  * @brief Get VLAN identifier from TCI.
  *

--- a/include/zephyr/net/lldp.h
+++ b/include/zephyr/net/lldp.h
@@ -226,16 +226,6 @@ typedef enum net_verdict (*net_lldp_recv_cb_t)(struct net_if *iface,
 int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t cb);
 
 /**
- * @brief Parse LLDP packet
- *
- * @param iface Network interface
- * @param pkt Network packet
- *
- * @return Return the policy for network buffer
- */
-enum net_verdict net_lldp_recv(struct net_if *iface, struct net_pkt *pkt);
-
-/**
  * @brief Set LLDP protocol data unit (LLDPDU) for the network interface.
  *
  * @param iface Network interface

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -21,6 +21,7 @@
 #include <zephyr/kernel.h>
 
 #include <zephyr/net/net_timeout.h>
+#include <zephyr/net/net_linkaddr.h>
 
 #ifdef __cplusplus
 extern "C" {
@@ -153,6 +154,40 @@ int net_send_data(struct net_pkt *pkt);
 #define NET_TC_RX_COUNT 0
 #define NET_TC_COUNT 0
 #endif /* CONFIG_NET_TC_TX_COUNT && CONFIG_NET_TC_RX_COUNT */
+
+/**
+ * @brief Registration information for a given L3 handler. Note that
+ *        the layer number (L3) just refers to something that is on top
+ *        of L2. So for example IPv6 is L3 and IPv4 is L3, but Ethernet
+ *        based LLDP, gPTP are more in the layer 2.5 but we consider them
+ *        as L3 here for simplicity.
+ */
+struct net_l3_register {
+	/** Store also the name of the L3 type in order to be able to
+	 * print it later.
+	 */
+	const char * const name;
+	/** What L2 layer this is for */
+	const struct net_l2 * const l2;
+	/** Handler function for the given protocol type */
+	enum net_verdict (*handler)(struct net_if *iface,
+				    uint16_t ptype,
+				    struct net_pkt *pkt);
+	/** Protocol type */
+	uint16_t ptype;
+};
+
+#define NET_L3_GET_NAME(l3_name, ptype) __net_l3_register_##l3_name##_##ptype
+
+#define NET_L3_REGISTER(_l2_type, _name, _ptype, _handler)		\
+	static const STRUCT_SECTION_ITERABLE(net_l3_register,		\
+				    NET_L3_GET_NAME(_name, _ptype)) = { \
+		.ptype = _ptype,					\
+		.handler = _handler,					\
+		.name = STRINGIFY(_name),				\
+		.l2 = _l2_type,						\
+	};								\
+	BUILD_ASSERT((_handler) != NULL, "Handler is not defined")
 
 /* @endcond */
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -605,7 +605,8 @@ struct net_traffic_class {
 	/** Fifo for handling this Tx or Rx packet */
 	struct k_fifo fifo;
 
-#if NET_TC_COUNT > 1 || defined(CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO)
+#if NET_TC_COUNT > 1 || defined(CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO) \
+	|| defined(CONFIG_NET_TC_RX_SKIP_FOR_HIGH_PRIO)
 	/** Semaphore for tracking the available slots in the fifo */
 	struct k_sem fifo_slot;
 #endif

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -605,6 +605,11 @@ struct net_traffic_class {
 	/** Fifo for handling this Tx or Rx packet */
 	struct k_fifo fifo;
 
+#if NET_TC_COUNT > 1 || defined(CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO)
+	/** Semaphore for tracking the available slots in the fifo */
+	struct k_sem fifo_slot;
+#endif
+
 	/** Traffic class handler thread */
 	struct k_thread handler;
 

--- a/include/zephyr/net/net_stats.h
+++ b/include/zephyr/net/net_stats.h
@@ -293,6 +293,8 @@ struct net_stats_tc {
 #endif
 		/** Number of packets sent for this traffic class */
 		net_stats_t pkts;
+		/** Number of packets dropped for this traffic class */
+		net_stats_t dropped;
 		/** Number of bytes sent for this traffic class */
 		net_stats_t bytes;
 		/** Priority of this traffic class */
@@ -310,6 +312,8 @@ struct net_stats_tc {
 #endif
 		/** Number of packets received for this traffic class */
 		net_stats_t pkts;
+		/** Number of packets dropped for this traffic class */
+		net_stats_t dropped;
 		/** Number of bytes received for this traffic class */
 		net_stats_t bytes;
 		/** Priority of this traffic class */

--- a/modules/hostap/src/supp_main.c
+++ b/modules/hostap/src/supp_main.c
@@ -1201,3 +1201,16 @@ static int init(void)
 }
 
 SYS_INIT(init, APPLICATION, 0);
+
+static enum net_verdict eapol_recv(struct net_if *iface, uint16_t ptype,
+				   struct net_pkt *pkt)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(ptype);
+
+	net_pkt_set_family(pkt, AF_UNSPEC);
+
+	return NET_CONTINUE;
+}
+
+ETH_NET_L3_REGISTER(EAPOL, NET_ETH_PTYPE_EAPOL, eapol_recv);

--- a/subsys/net/ip/Kconfig
+++ b/subsys/net/ip/Kconfig
@@ -386,6 +386,19 @@ config NET_TC_SKIP_FOR_HIGH_PRIO
 	  be pushed directly to network driver and will skip the traffic class
 	  queues. This is currently not enabled by default.
 
+config NET_TC_RX_SKIP_FOR_HIGH_PRIO
+	bool "Push high priority packets directly to the application"
+	help
+	  If this is set, then high priority (>= NET_PRIORITY_CA) net_pkt will
+	  be pushed directly to the application and will skip the traffic class
+	  queues. If you select this option, then it means that high priority
+	  network traffic is pushed from the driver to the application thread
+	  without any intermediate RX queue. If the network device driver is
+	  running in IRQ context, it will handle the packet all the way to the
+	  application. This might cause other incoming packets to be lost if
+	  the RX processing takes long time.
+	  This is currently not enabled by default.
+
 choice NET_TC_THREAD_TYPE
 	prompt "How the network RX/TX threads should work"
 	help

--- a/subsys/net/ip/Kconfig.ipv4
+++ b/subsys/net/ip/Kconfig.ipv4
@@ -13,7 +13,7 @@ if NET_IPV4
 
 config NET_IF_MAX_IPV4_COUNT
 	int "Max number of IPv4 network interfaces in the system"
-	default NET_VLAN_COUNT if NET_VLAN
+	default NET_VLAN_COUNT if NET_VLAN && NET_VLAN_COUNT > 0
 	default 2 if NET_LOOPBACK
 	default 1
 	help

--- a/subsys/net/ip/Kconfig.ipv6
+++ b/subsys/net/ip/Kconfig.ipv6
@@ -14,7 +14,7 @@ if NET_IPV6
 
 config NET_IF_MAX_IPV6_COUNT
 	int "Max number of IPv6 network interfaces in the system"
-	default NET_VLAN_COUNT if NET_VLAN
+	default NET_VLAN_COUNT if NET_VLAN && NET_VLAN_COUNT > 0
 	default 2 if NET_LOOPBACK
 	default 1
 	help

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -465,14 +465,9 @@ void net_process_rx_packet(struct net_pkt *pkt)
 
 static void net_queue_rx(struct net_if *iface, struct net_pkt *pkt)
 {
+	size_t len = net_pkt_get_len(pkt);
 	uint8_t prio = net_pkt_priority(pkt);
 	uint8_t tc = net_rx_priority2tc(prio);
-
-#if defined(CONFIG_NET_STATISTICS)
-	net_stats_update_tc_recv_pkt(iface, tc);
-	net_stats_update_tc_recv_bytes(iface, tc, net_pkt_get_len(pkt));
-	net_stats_update_tc_recv_priority(iface, tc, prio);
-#endif
 
 #if NET_TC_RX_COUNT > 1
 	NET_DBG("TC %d with prio %d pkt %p", tc, prio, pkt);
@@ -486,11 +481,14 @@ static void net_queue_rx(struct net_if *iface, struct net_pkt *pkt)
 		}
 	}
 
+	net_stats_update_tc_recv_pkt(iface, tc);
+	net_stats_update_tc_recv_bytes(iface, tc, len);
+	net_stats_update_tc_recv_priority(iface, tc, prio);
 	return;
 
 drop:
 	net_pkt_unref(pkt);
-	/* TODO add statistics */
+	net_stats_update_tc_recv_dropped(iface, tc);
 	return;
 }
 

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -473,7 +473,8 @@ static void net_queue_rx(struct net_if *iface, struct net_pkt *pkt)
 	NET_DBG("TC %d with prio %d pkt %p", tc, prio, pkt);
 #endif
 
-	if (NET_TC_RX_COUNT == 0) {
+	if ((IS_ENABLED(CONFIG_NET_TC_RX_SKIP_FOR_HIGH_PRIO) &&
+	     prio >= NET_PRIORITY_CA) || NET_TC_RX_COUNT == 0) {
 		net_process_rx_packet(pkt);
 	} else {
 		if (net_tc_submit_to_rx_queue(tc, pkt) != NET_OK) {

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -481,8 +481,17 @@ static void net_queue_rx(struct net_if *iface, struct net_pkt *pkt)
 	if (NET_TC_RX_COUNT == 0) {
 		net_process_rx_packet(pkt);
 	} else {
-		net_tc_submit_to_rx_queue(tc, pkt);
+		if (net_tc_submit_to_rx_queue(tc, pkt) != NET_OK) {
+			goto drop;
+		}
 	}
+
+	return;
+
+drop:
+	net_pkt_unref(pkt);
+	/* TODO add statistics */
+	return;
 }
 
 /* Called by driver when a packet has been received */

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -357,6 +357,10 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 	net_stats_update_tc_sent_bytes(iface, tc, net_pkt_get_len(pkt));
 	net_stats_update_tc_sent_priority(iface, tc, prio);
 
+#if NET_TC_TX_COUNT > 1
+	NET_DBG("TC %d with prio %d pkt %p", tc, prio, pkt);
+#endif
+
 	/* For highest priority packet, skip the TX queue and push directly to
 	 * the driver. Also if there are no TX queue/thread, push the packet
 	 * directly to the driver.
@@ -366,23 +370,21 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 		net_pkt_set_tx_stats_tick(pkt, k_cycle_get_32());
 
 		net_if_tx(net_pkt_iface(pkt), pkt);
-		return;
+	} else {
+		if (net_tc_submit_to_tx_queue(tc, pkt) != NET_OK) {
+			goto drop;
+		}
+#if defined(CONFIG_NET_POWER_MANAGEMENT)
+		iface->tx_pending++;
+#endif
 	}
 
-#if NET_TC_TX_COUNT > 1
-	NET_DBG("TC %d with prio %d pkt %p", tc, prio, pkt);
-#endif
+	return;
 
-#if defined(CONFIG_NET_POWER_MANAGEMENT)
-	iface->tx_pending++;
-#endif
-
-	if (!net_tc_submit_to_tx_queue(tc, pkt)) {
-#if defined(CONFIG_NET_POWER_MANAGEMENT)
-		iface->tx_pending--
-#endif
-			;
-	}
+drop:
+	net_pkt_unref(pkt);
+	/* TODO add statistics */
+	return;
 }
 #endif /* CONFIG_NET_NATIVE */
 

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -350,12 +350,9 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 		return;
 	}
 
+	size_t len = net_pkt_get_len(pkt);
 	uint8_t prio = net_pkt_priority(pkt);
 	uint8_t tc = net_tx_priority2tc(prio);
-
-	net_stats_update_tc_sent_pkt(iface, tc);
-	net_stats_update_tc_sent_bytes(iface, tc, net_pkt_get_len(pkt));
-	net_stats_update_tc_sent_priority(iface, tc, prio);
 
 #if NET_TC_TX_COUNT > 1
 	NET_DBG("TC %d with prio %d pkt %p", tc, prio, pkt);
@@ -379,11 +376,14 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 #endif
 	}
 
+	net_stats_update_tc_sent_pkt(iface, tc);
+	net_stats_update_tc_sent_bytes(iface, tc, len);
+	net_stats_update_tc_sent_priority(iface, tc, prio);
 	return;
 
 drop:
 	net_pkt_unref(pkt);
-	/* TODO add statistics */
+	net_stats_update_tc_sent_dropped(iface, tc);
 	return;
 }
 #endif /* CONFIG_NET_NATIVE */

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -169,8 +169,8 @@ static inline enum net_verdict net_ipv6_input(struct net_pkt *pkt,
 static inline void net_tc_tx_init(void) { }
 static inline void net_tc_rx_init(void) { }
 #endif
-extern bool net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt);
-extern void net_tc_submit_to_rx_queue(uint8_t tc, struct net_pkt *pkt);
+extern enum net_verdict net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt);
+extern enum net_verdict net_tc_submit_to_rx_queue(uint8_t tc, struct net_pkt *pkt);
 extern enum net_verdict net_promisc_mode_input(struct net_pkt *pkt);
 
 char *net_sprint_addr(sa_family_t af, const void *addr);

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -224,18 +224,8 @@ void net_if_ipv6_start_dad(struct net_if *iface,
  * @brief Initialize Precision Time Protocol Layer.
  */
 void net_gptp_init(void);
-
-/**
- * @brief Process a ptp message.
- *
- * @param buf Buffer with a valid PTP Ethernet type.
- *
- * @return Return the policy for network buffer.
- */
-enum net_verdict net_gptp_recv(struct net_if *iface, struct net_pkt *pkt);
 #else
 #define net_gptp_init()
-#define net_gptp_recv(iface, pkt) NET_DROP
 #endif /* CONFIG_NET_GPTP */
 
 #if defined(CONFIG_NET_IPV4_FRAGMENT)

--- a/subsys/net/ip/net_stats.h
+++ b/subsys/net/ip/net_stats.h
@@ -439,6 +439,11 @@ static inline void net_stats_update_tc_sent_pkt(struct net_if *iface, uint8_t tc
 	UPDATE_STAT(iface, stats.tc.sent[tc].pkts++);
 }
 
+static inline void net_stats_update_tc_sent_dropped(struct net_if *iface, uint8_t tc)
+{
+	UPDATE_STAT(iface, stats.tc.sent[tc].dropped++);
+}
+
 static inline void net_stats_update_tc_sent_bytes(struct net_if *iface,
 						  uint8_t tc, size_t bytes)
 {
@@ -540,6 +545,11 @@ static inline void net_stats_update_tc_recv_pkt(struct net_if *iface, uint8_t tc
 	UPDATE_STAT(iface, stats.tc.recv[tc].pkts++);
 }
 
+static inline void net_stats_update_tc_recv_dropped(struct net_if *iface, uint8_t tc)
+{
+	UPDATE_STAT(iface, stats.tc.recv[tc].dropped++);
+}
+
 static inline void net_stats_update_tc_recv_bytes(struct net_if *iface,
 						  uint8_t tc, size_t bytes)
 {
@@ -552,12 +562,61 @@ static inline void net_stats_update_tc_recv_priority(struct net_if *iface,
 	UPDATE_STAT(iface, stats.tc.recv[tc].priority = priority);
 }
 #else
-#define net_stats_update_tc_sent_pkt(iface, tc)
-#define net_stats_update_tc_sent_bytes(iface, tc, bytes)
-#define net_stats_update_tc_sent_priority(iface, tc, priority)
-#define net_stats_update_tc_recv_pkt(iface, tc)
-#define net_stats_update_tc_recv_bytes(iface, tc, bytes)
-#define net_stats_update_tc_recv_priority(iface, tc, priority)
+static inline void net_stats_update_tc_sent_pkt(struct net_if *iface, uint8_t tc)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+}
+
+static inline void net_stats_update_tc_sent_dropped(struct net_if *iface, uint8_t tc)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+}
+
+static inline void net_stats_update_tc_sent_bytes(struct net_if *iface,
+						  uint8_t tc, size_t bytes)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+	ARG_UNUSED(bytes);
+}
+
+static inline void net_stats_update_tc_sent_priority(struct net_if *iface,
+						     uint8_t tc, uint8_t priority)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+	ARG_UNUSED(priority);
+}
+
+static inline void net_stats_update_tc_recv_pkt(struct net_if *iface, uint8_t tc)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+}
+
+static inline void net_stats_update_tc_recv_dropped(struct net_if *iface, uint8_t tc)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+}
+
+static inline void net_stats_update_tc_recv_bytes(struct net_if *iface,
+						  uint8_t tc, size_t bytes)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+	ARG_UNUSED(bytes);
+}
+
+static inline void net_stats_update_tc_recv_priority(struct net_if *iface,
+						     uint8_t tc, uint8_t priority)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(tc);
+	ARG_UNUSED(priority);
+}
 
 #if defined(CONFIG_NET_PKT_TXTIME_STATS) && \
 	defined(CONFIG_NET_STATISTICS) && defined(CONFIG_NET_NATIVE)

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -18,6 +18,25 @@ LOG_MODULE_REGISTER(net_tc, CONFIG_NET_TC_LOG_LEVEL);
 #include "net_stats.h"
 #include "net_tc_mapping.h"
 
+#if NET_TC_RX_COUNT > 1
+#define NET_TC_RX_SLOTS (CONFIG_NET_PKT_RX_COUNT / NET_TC_RX_COUNT)
+BUILD_ASSERT(NET_TC_RX_SLOTS > 0,
+		"Misconfiguration: There are more traffic classes then packets, "
+		"either increase CONFIG_NET_PKT_RX_COUNT or decrease "
+		"CONFIG_NET_TC_RX_COUNT");
+#endif
+
+#define TC_TX_PSEUDO_QUEUE (COND_CODE_1(CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO, (1), (0)))
+#define NET_TC_TX_EFFECTIVE_COUNT (NET_TC_TX_COUNT + TC_TX_PSEUDO_QUEUE)
+
+#if NET_TC_TX_EFFECTIVE_COUNT > 1
+#define NET_TC_TX_SLOTS (CONFIG_NET_PKT_TX_COUNT / NET_TC_TX_EFFECTIVE_COUNT)
+BUILD_ASSERT(NET_TC_TX_SLOTS > 0,
+		"Misconfiguration: There are more traffic classes then packets, "
+		"either increase CONFIG_NET_PKT_TX_COUNT or decrease "
+		"CONFIG_NET_TC_TX_COUNT or disable CONFIG_NET_TC_SKIP_FOR_HIGH_PRIO");
+#endif
+
 /* Template for thread name. The "xx" is either "TX" denoting transmit thread,
  * or "RX" denoting receive thread. The "q[y]" denotes the traffic class queue
  * where y indicates the traffic class id. The value of y can be from 0 to 7.
@@ -40,35 +59,43 @@ static struct net_traffic_class tx_classes[NET_TC_TX_COUNT];
 static struct net_traffic_class rx_classes[NET_TC_RX_COUNT];
 #endif
 
-#if NET_TC_RX_COUNT > 0 || NET_TC_TX_COUNT > 0
-static void submit_to_queue(struct k_fifo *queue, struct net_pkt *pkt)
-{
-	k_fifo_put(queue, pkt);
-}
-#endif
-
-bool net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt)
+enum net_verdict net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt)
 {
 #if NET_TC_TX_COUNT > 0
 	net_pkt_set_tx_stats_tick(pkt, k_cycle_get_32());
 
-	submit_to_queue(&tx_classes[tc].fifo, pkt);
+#if NET_TC_TX_EFFECTIVE_COUNT > 1
+	if (k_sem_take(&tx_classes[tc].fifo_slot, K_NO_WAIT) != 0) {
+		return NET_DROP;
+	}
+#endif
+
+	k_fifo_put(&tx_classes[tc].fifo, pkt);
+	return NET_OK;
 #else
 	ARG_UNUSED(tc);
 	ARG_UNUSED(pkt);
+	return NET_DROP;
 #endif
-	return true;
 }
 
-void net_tc_submit_to_rx_queue(uint8_t tc, struct net_pkt *pkt)
+enum net_verdict net_tc_submit_to_rx_queue(uint8_t tc, struct net_pkt *pkt)
 {
 #if NET_TC_RX_COUNT > 0
 	net_pkt_set_rx_stats_tick(pkt, k_cycle_get_32());
 
-	submit_to_queue(&rx_classes[tc].fifo, pkt);
+#if NET_TC_RX_COUNT > 1
+	if (k_sem_take(&rx_classes[tc].fifo_slot, K_NO_WAIT) != 0) {
+		return NET_DROP;
+	}
+#endif
+
+	k_fifo_put(&rx_classes[tc].fifo, pkt);
+	return NET_OK;
 #else
 	ARG_UNUSED(tc);
 	ARG_UNUSED(pkt);
+	return NET_DROP;
 #endif
 }
 
@@ -242,10 +269,14 @@ static void net_tc_rx_stats_priority_setup(struct net_if *iface,
 #if NET_TC_RX_COUNT > 0
 static void tc_rx_handler(void *p1, void *p2, void *p3)
 {
-	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
 	struct k_fifo *fifo = p1;
+#if NET_TC_RX_COUNT > 1
+	struct k_sem *fifo_slot = p2;
+#else
+	ARG_UNUSED(p2);
+#endif
 	struct net_pkt *pkt;
 
 	while (1) {
@@ -253,6 +284,10 @@ static void tc_rx_handler(void *p1, void *p2, void *p3)
 		if (pkt == NULL) {
 			continue;
 		}
+
+#if NET_TC_RX_COUNT > 1
+		k_sem_give(fifo_slot);
+#endif
 
 		net_process_rx_packet(pkt);
 	}
@@ -262,10 +297,14 @@ static void tc_rx_handler(void *p1, void *p2, void *p3)
 #if NET_TC_TX_COUNT > 0
 static void tc_tx_handler(void *p1, void *p2, void *p3)
 {
-	ARG_UNUSED(p2);
 	ARG_UNUSED(p3);
 
 	struct k_fifo *fifo = p1;
+#if NET_TC_TX_EFFECTIVE_COUNT > 1
+	struct k_sem *fifo_slot = p2;
+#else
+	ARG_UNUSED(p2);
+#endif
 	struct net_pkt *pkt;
 
 	while (1) {
@@ -273,6 +312,10 @@ static void tc_tx_handler(void *p1, void *p2, void *p3)
 		if (pkt == NULL) {
 			continue;
 		}
+
+#if NET_TC_TX_EFFECTIVE_COUNT > 1
+		k_sem_give(fifo_slot);
+#endif
 
 		net_process_tx_packet(pkt);
 	}
@@ -318,10 +361,20 @@ void net_tc_tx_init(void)
 
 		k_fifo_init(&tx_classes[i].fifo);
 
+#if NET_TC_TX_EFFECTIVE_COUNT > 1
+		k_sem_init(&tx_classes[i].fifo_slot, NET_TC_TX_SLOTS, NET_TC_TX_SLOTS);
+#endif
+
 		tid = k_thread_create(&tx_classes[i].handler, tx_stack[i],
 				      K_KERNEL_STACK_SIZEOF(tx_stack[i]),
 				      tc_tx_handler,
-				      &tx_classes[i].fifo, NULL, NULL,
+				      &tx_classes[i].fifo,
+#if NET_TC_TX_EFFECTIVE_COUNT > 1
+				      &tx_classes[i].fifo_slot,
+#else
+				      NULL,
+#endif
+				      NULL,
 				      priority, 0, K_FOREVER);
 		if (!tid) {
 			NET_ERR("Cannot create TC handler thread %d", i);
@@ -376,10 +429,20 @@ void net_tc_rx_init(void)
 
 		k_fifo_init(&rx_classes[i].fifo);
 
+#if NET_TC_RX_COUNT > 1
+		k_sem_init(&rx_classes[i].fifo_slot, NET_TC_RX_SLOTS, NET_TC_RX_SLOTS);
+#endif
+
 		tid = k_thread_create(&rx_classes[i].handler, rx_stack[i],
 				      K_KERNEL_STACK_SIZEOF(rx_stack[i]),
 				      tc_rx_handler,
-				      &rx_classes[i].fifo, NULL, NULL,
+				      &rx_classes[i].fifo,
+#if NET_TC_RX_COUNT > 1
+				      &rx_classes[i].fifo_slot,
+#else
+				      NULL,
+#endif
+				      NULL,
 				      priority, 0, K_FOREVER);
 		if (!tid) {
 			NET_ERR("Cannot create TC handler thread %d", i);

--- a/subsys/net/l2/ethernet/Kconfig
+++ b/subsys/net/l2/ethernet/Kconfig
@@ -33,10 +33,14 @@ config NET_VLAN
 config NET_VLAN_COUNT
 	int "Max VLAN tags supported in the system"
 	default 1
-	range 1 $(UINT8_MAX)
+	range 0 $(UINT8_MAX)
 	depends on NET_VLAN
 	help
-	  How many VLAN tags can be configured.
+	  How many VLAN tags can be configured. If set to 0, then only
+	  priority tagged VLAN frames with tag value 0 can be handled.
+	  This is useful if you do not want to receive any other VLAN
+	  tagged frames than tag 0. This will save some memory as the
+	  VLAN virtual interface is not created in this case.
 
 config NET_VLAN_TXRX_DEBUG
 	bool "Debug received and sent packets in VLAN"

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -19,6 +19,7 @@ LOG_MODULE_REGISTER(net_arp, CONFIG_NET_ARP_LOG_LEVEL);
 #include <zephyr/net/net_mgmt.h>
 
 #include "arp.h"
+#include "ipv4.h"
 #include "net_private.h"
 
 #define NET_BUF_TIMEOUT K_MSEC(100)
@@ -1003,3 +1004,28 @@ void net_arp_init(void)
 			  K_SECONDS(CONFIG_NET_ARP_GRATUITOUS_INTERVAL));
 #endif /* defined(CONFIG_NET_ARP_GRATUITOUS_TRANSMISSION) */
 }
+
+static enum net_verdict arp_recv(struct net_if *iface,
+				 uint16_t ptype,
+				 struct net_pkt *pkt)
+{
+	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
+
+	ARG_UNUSED(iface);
+	ARG_UNUSED(ptype);
+
+	net_pkt_set_family(pkt, AF_INET);
+
+	NET_DBG("ARP packet from %s received",
+		net_sprint_ll_addr((uint8_t *)hdr->src.addr,
+				   sizeof(struct net_eth_addr)));
+
+	if (IS_ENABLED(CONFIG_NET_IPV4_ACD) &&
+	    net_ipv4_acd_input(iface, pkt) == NET_DROP) {
+		return NET_DROP;
+	}
+
+	return net_arp_input(pkt, hdr);
+}
+
+ETH_NET_L3_REGISTER(ARP, NET_ETH_PTYPE_ARP, arp_recv);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -298,14 +298,16 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 				goto drop;
 			}
 
-			/* We could call VLAN interface directly but then the
-			 * interface statistics would not get updated so route
-			 * the call via Virtual L2 layer.
-			 */
-			if (net_if_l2(net_pkt_iface(pkt))->recv != NULL) {
-				verdict = net_if_l2(net_pkt_iface(pkt))->recv(iface, pkt);
-				if (verdict == NET_DROP) {
-					goto drop;
+			if (net_pkt_vlan_tag(pkt) != NET_VLAN_TAG_PRIORITY) {
+				/* We could call VLAN interface directly but then the
+				 * interface statistics would not get updated so route
+				 * the call via Virtual L2 layer.
+				 */
+				if (net_if_l2(net_pkt_iface(pkt))->recv != NULL) {
+					verdict = net_if_l2(net_pkt_iface(pkt))->recv(iface, pkt);
+					if (verdict == NET_DROP) {
+						goto drop;
+					}
 				}
 			}
 		}

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -236,11 +236,13 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 				      struct net_pkt *pkt)
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
-	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
 	uint8_t hdr_len = sizeof(struct net_eth_hdr);
-	uint16_t type;
-	struct net_linkaddr *lladdr;
+	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
+	enum net_verdict verdict = NET_CONTINUE;
 	bool is_vlan_pkt = false;
+	bool handled = false;
+	struct net_linkaddr *lladdr;
+	uint16_t type;
 
 	/* This expects that the Ethernet header is in the first net_buf
 	 * fragment. This is a safe expectation here as it would not make
@@ -279,7 +281,6 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		    !eth_is_vlan_tag_stripped(iface)) {
 			struct net_eth_vlan_hdr *hdr_vlan =
 				(struct net_eth_vlan_hdr *)NET_ETH_HDR(pkt);
-			enum net_verdict verdict;
 
 			net_pkt_set_vlan_tci(pkt, ntohs(hdr_vlan->vlan.tci));
 			type = ntohs(hdr_vlan->type);
@@ -310,39 +311,6 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		}
 	}
 
-	switch (type) {
-	case NET_ETH_PTYPE_IP:
-	case NET_ETH_PTYPE_ARP:
-		net_pkt_set_family(pkt, AF_INET);
-		break;
-	case NET_ETH_PTYPE_IPV6:
-		net_pkt_set_family(pkt, AF_INET6);
-		break;
-	case NET_ETH_PTYPE_EAPOL:
-		break;
-#if defined(CONFIG_NET_L2_PTP)
-	case NET_ETH_PTYPE_PTP:
-		break;
-#endif
-	case NET_ETH_PTYPE_LLDP:
-#if defined(CONFIG_NET_LLDP)
-		net_buf_pull(pkt->frags, hdr_len);
-		return net_lldp_recv(iface, pkt);
-#else
-		NET_DBG("LLDP Rx agent not enabled");
-		goto drop;
-#endif
-	default:
-		if (IS_ENABLED(CONFIG_NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE)) {
-			break;
-		}
-
-		NET_DBG("Unknown hdr type 0x%04x iface %d (%p)", type,
-			net_if_get_by_iface(iface), iface);
-		eth_stats_update_unknown_protocol(iface);
-		return NET_DROP;
-	}
-
 	/* Set the pointers to ll src and dst addresses */
 	lladdr = net_pkt_lladdr_src(pkt);
 	lladdr->addr = hdr->src.addr;
@@ -370,9 +338,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 
 	if (!net_eth_is_addr_broadcast((struct net_eth_addr *)lladdr->addr) &&
 	    !net_eth_is_addr_multicast((struct net_eth_addr *)lladdr->addr) &&
-	    !net_eth_is_addr_lldp_multicast(
-		    (struct net_eth_addr *)lladdr->addr) &&
-	    !net_eth_is_addr_ptp_multicast((struct net_eth_addr *)lladdr->addr) &&
+	    !net_eth_is_addr_group((struct net_eth_addr *)lladdr->addr) &&
 	    !net_linkaddr_cmp(net_if_get_link_addr(iface), lladdr)) {
 		/* The ethernet frame is not for me as the link addresses
 		 * are different.
@@ -383,43 +349,92 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		goto drop;
 	}
 
+	/* Get rid of the Ethernet header. */
 	net_buf_pull(pkt->frags, hdr_len);
 
-	if (IS_ENABLED(CONFIG_NET_IPV4) && type == NET_ETH_PTYPE_IP &&
-	    ethernet_check_ipv4_bcast_addr(pkt, hdr) == NET_DROP) {
-		goto drop;
+	STRUCT_SECTION_FOREACH(net_l3_register, l3) {
+		if (l3->ptype != type || l3->l2 != &NET_L2_GET_NAME(ETHERNET)) {
+			continue;
+		}
+
+		NET_DBG("Calling L3 %s handler for type 0x%04x iface %d (%p)",
+			l3->name, type, net_if_get_by_iface(iface), iface);
+
+		verdict = l3->handler(iface, type, pkt);
+		if (verdict == NET_DROP) {
+			NET_DBG("Dropping frame, packet rejected by %s", l3->name);
+			goto drop;
+		}
+
+		handled = true;
+		break;
+	}
+
+	if (!handled) {
+		if (IS_ENABLED(CONFIG_NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE)) {
+			net_pkt_set_family(pkt, AF_UNSPEC);
+		} else {
+			NET_DBG("Unknown hdr type 0x%04x iface %d (%p)", type,
+				net_if_get_by_iface(iface), iface);
+			eth_stats_update_unknown_protocol(iface);
+			return NET_DROP;
+		}
+	}
+
+	/* FIXME: ARP eats the packet and the pkt is no longer a valid one,
+	 * so we cannot update the stats here. Fix the code to be more generic
+	 * so that we do not need this check.
+	 */
+	if (type == NET_ETH_PTYPE_ARP) {
+		return verdict;
 	}
 
 	ethernet_update_rx_stats(iface, hdr, net_pkt_get_len(pkt) + hdr_len);
-
-	if (IS_ENABLED(CONFIG_NET_ARP) && type == NET_ETH_PTYPE_ARP) {
-		NET_DBG("ARP packet from %s received",
-			net_sprint_ll_addr((uint8_t *)hdr->src.addr,
-					   sizeof(struct net_eth_addr)));
-
-		if (IS_ENABLED(CONFIG_NET_IPV4_ACD) &&
-		    net_ipv4_acd_input(iface, pkt) == NET_DROP) {
-			return NET_DROP;
-		}
-
-		return net_arp_input(pkt, hdr);
-	}
-
-	if (IS_ENABLED(CONFIG_NET_GPTP) && type == NET_ETH_PTYPE_PTP) {
-		return net_gptp_recv(iface, pkt);
-	}
 
 	if (type != NET_ETH_PTYPE_EAPOL) {
 		ethernet_update_length(iface, pkt);
 	}
 
-	return NET_CONTINUE;
+	return verdict;
 drop:
 	eth_stats_update_errors_rx(iface);
 	return NET_DROP;
 }
 
+#if defined(CONFIG_NET_IPV4) || defined(CONFIG_NET_IPV6)
+static enum net_verdict ethernet_ip_recv(struct net_if *iface,
+					 uint16_t ptype,
+					 struct net_pkt *pkt)
+{
+	ARG_UNUSED(iface);
+
+	if (ptype == NET_ETH_PTYPE_IP) {
+		struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
+
+		if (ethernet_check_ipv4_bcast_addr(pkt, hdr) == NET_DROP) {
+			return NET_DROP;
+		}
+
+		net_pkt_set_family(pkt, AF_INET);
+	} else if (ptype == NET_ETH_PTYPE_IPV6) {
+		net_pkt_set_family(pkt, AF_INET6);
+	} else {
+		return NET_DROP;
+	}
+
+	return NET_CONTINUE;
+}
+#endif /* CONFIG_NET_IPV4 || CONFIG_NET_IPV6 */
+
 #ifdef CONFIG_NET_IPV4
+ETH_NET_L3_REGISTER(IPv4, NET_ETH_PTYPE_IP, ethernet_ip_recv);
+#endif
+
+#if defined(CONFIG_NET_IPV6)
+ETH_NET_L3_REGISTER(IPv6, NET_ETH_PTYPE_IPV6, ethernet_ip_recv);
+#endif /* CONFIG_NET_IPV6 */
+
+#if defined(CONFIG_NET_IPV4)
 static inline bool ethernet_ipv4_dst_is_broadcast_or_mcast(struct net_pkt *pkt)
 {
 	if (net_ipv4_is_addr_bcast(net_pkt_iface(pkt),

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -149,16 +149,16 @@ static inline void ethernet_update_length(struct net_if *iface,
 	}
 }
 
-static void ethernet_update_rx_stats(struct net_if *iface,
-				     struct net_eth_hdr *hdr, size_t length)
+
+static void ethernet_update_rx_stats(struct net_if *iface, size_t length,
+				     bool dst_broadcast, bool dst_eth_multicast)
 {
 #if defined(CONFIG_NET_STATISTICS_ETHERNET)
 	eth_stats_update_bytes_rx(iface, length);
 	eth_stats_update_pkts_rx(iface);
-
-	if (net_eth_is_addr_broadcast(&hdr->dst)) {
+	if (dst_broadcast) {
 		eth_stats_update_broadcast_rx(iface);
-	} else if (net_eth_is_addr_multicast(&hdr->dst)) {
+	} else if (dst_eth_multicast) {
 		eth_stats_update_multicast_rx(iface);
 	}
 #endif /* CONFIG_NET_STATISTICS_ETHERNET */
@@ -237,12 +237,14 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 {
 	struct ethernet_context *ctx = net_if_l2_data(iface);
 	uint8_t hdr_len = sizeof(struct net_eth_hdr);
+	size_t body_len;
 	struct net_eth_hdr *hdr = NET_ETH_HDR(pkt);
 	enum net_verdict verdict = NET_CONTINUE;
 	bool is_vlan_pkt = false;
 	bool handled = false;
 	struct net_linkaddr *lladdr;
 	uint16_t type;
+	bool dst_broadcast, dst_eth_multicast, dst_iface_addr;
 
 	/* This expects that the Ethernet header is in the first net_buf
 	 * fragment. This is a safe expectation here as it would not make
@@ -325,6 +327,9 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	lladdr->type = NET_LINK_ETHERNET;
 
 	net_pkt_set_ll_proto_type(pkt, type);
+	dst_broadcast = net_eth_is_addr_broadcast((struct net_eth_addr *)lladdr->addr);
+	dst_eth_multicast = net_eth_is_addr_group((struct net_eth_addr *)lladdr->addr);
+	dst_iface_addr = net_linkaddr_cmp(net_if_get_link_addr(iface), lladdr);
 
 	if (is_vlan_pkt) {
 		print_vlan_ll_addrs(pkt, type, net_pkt_vlan_tci(pkt),
@@ -338,10 +343,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 			       net_pkt_lladdr_dst(pkt));
 	}
 
-	if (!net_eth_is_addr_broadcast((struct net_eth_addr *)lladdr->addr) &&
-	    !net_eth_is_addr_multicast((struct net_eth_addr *)lladdr->addr) &&
-	    !net_eth_is_addr_group((struct net_eth_addr *)lladdr->addr) &&
-	    !net_linkaddr_cmp(net_if_get_link_addr(iface), lladdr)) {
+	if (!(dst_broadcast || dst_eth_multicast || dst_iface_addr)) {
 		/* The ethernet frame is not for me as the link addresses
 		 * are different.
 		 */
@@ -354,6 +356,8 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	/* Get rid of the Ethernet header. */
 	net_buf_pull(pkt->frags, hdr_len);
 
+	body_len = net_pkt_get_len(pkt);
+
 	STRUCT_SECTION_FOREACH(net_l3_register, l3) {
 		if (l3->ptype != type || l3->l2 != &NET_L2_GET_NAME(ETHERNET)) {
 			continue;
@@ -363,7 +367,10 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 			l3->name, type, net_if_get_by_iface(iface), iface);
 
 		verdict = l3->handler(iface, type, pkt);
-		if (verdict == NET_DROP) {
+		if (verdict == NET_OK) {
+			/* the packet was consumed by the l3-handler */
+			goto out;
+		} else if (verdict == NET_DROP) {
 			NET_DBG("Dropping frame, packet rejected by %s", l3->name);
 			goto drop;
 		}
@@ -383,20 +390,12 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 		}
 	}
 
-	/* FIXME: ARP eats the packet and the pkt is no longer a valid one,
-	 * so we cannot update the stats here. Fix the code to be more generic
-	 * so that we do not need this check.
-	 */
-	if (type == NET_ETH_PTYPE_ARP) {
-		return verdict;
-	}
-
-	ethernet_update_rx_stats(iface, hdr, net_pkt_get_len(pkt) + hdr_len);
-
 	if (type != NET_ETH_PTYPE_EAPOL) {
 		ethernet_update_length(iface, pkt);
 	}
 
+out:
+	ethernet_update_rx_stats(iface, body_len + hdr_len, dst_broadcast, dst_eth_multicast);
 	return verdict;
 drop:
 	eth_stats_update_errors_rx(iface);

--- a/subsys/net/l2/ethernet/ethernet.c
+++ b/subsys/net/l2/ethernet/ethernet.c
@@ -240,7 +240,6 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	uint8_t hdr_len = sizeof(struct net_eth_hdr);
 	uint16_t type;
 	struct net_linkaddr *lladdr;
-	sa_family_t family = AF_UNSPEC;
 	bool is_vlan_pkt = false;
 
 	/* This expects that the Ethernet header is in the first net_buf
@@ -315,18 +314,14 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 	case NET_ETH_PTYPE_IP:
 	case NET_ETH_PTYPE_ARP:
 		net_pkt_set_family(pkt, AF_INET);
-		family = AF_INET;
 		break;
 	case NET_ETH_PTYPE_IPV6:
 		net_pkt_set_family(pkt, AF_INET6);
-		family = AF_INET6;
 		break;
 	case NET_ETH_PTYPE_EAPOL:
-		family = AF_UNSPEC;
 		break;
 #if defined(CONFIG_NET_L2_PTP)
 	case NET_ETH_PTYPE_PTP:
-		family = AF_UNSPEC;
 		break;
 #endif
 	case NET_ETH_PTYPE_LLDP:
@@ -339,7 +334,6 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 #endif
 	default:
 		if (IS_ENABLED(CONFIG_NET_ETHERNET_FORWARD_UNRECOGNISED_ETHERTYPE)) {
-			family = AF_UNSPEC;
 			break;
 		}
 
@@ -398,8 +392,7 @@ static enum net_verdict ethernet_recv(struct net_if *iface,
 
 	ethernet_update_rx_stats(iface, hdr, net_pkt_get_len(pkt) + hdr_len);
 
-	if (IS_ENABLED(CONFIG_NET_ARP) &&
-	    family == AF_INET && type == NET_ETH_PTYPE_ARP) {
+	if (IS_ENABLED(CONFIG_NET_ARP) && type == NET_ETH_PTYPE_ARP) {
 		NET_DBG("ARP packet from %s received",
 			net_sprint_ll_addr((uint8_t *)hdr->src.addr,
 					   sizeof(struct net_eth_addr)));

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -264,11 +264,18 @@ static int lldp_start(struct net_if *iface, uint32_t mgmt_event)
 	return 0;
 }
 
-enum net_verdict net_lldp_recv(struct net_if *iface, struct net_pkt *pkt)
+static enum net_verdict net_lldp_recv(struct net_if *iface, uint16_t ptype, struct net_pkt *pkt)
 {
 	struct ethernet_context *ctx;
 	net_lldp_recv_cb_t recv_cb;
 	int ret;
+
+	ARG_UNUSED(ptype);
+
+	if (!net_eth_is_addr_lldp_multicast(
+		    (struct net_eth_addr *)net_pkt_lladdr_dst(pkt)->addr)) {
+		return NET_DROP;
+	}
 
 	ret = lldp_check_iface(iface);
 	if (ret < 0) {
@@ -289,6 +296,8 @@ enum net_verdict net_lldp_recv(struct net_if *iface, struct net_pkt *pkt)
 
 	return NET_DROP;
 }
+
+ETH_NET_L3_REGISTER(LLDP, NET_ETH_PTYPE_LLDP, net_lldp_recv);
 
 int net_lldp_register_callback(struct net_if *iface, net_lldp_recv_cb_t recv_cb)
 {

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -215,6 +215,10 @@ struct net_if *net_eth_get_vlan_iface(struct net_if *iface, uint16_t tag)
 
 	ctx = get_vlan(iface, tag);
 	if (ctx == NULL) {
+		if (tag == NET_VLAN_TAG_PRIORITY) {
+			return iface;
+		}
+
 		return NULL;
 	}
 

--- a/subsys/net/l2/ethernet/vlan.c
+++ b/subsys/net/l2/ethernet/vlan.c
@@ -26,6 +26,12 @@ LOG_MODULE_REGISTER(net_ethernet_vlan, CONFIG_NET_L2_ETHERNET_LOG_LEVEL);
 #define DEBUG_RX 0
 #endif
 
+/* If the VLAN interface count is 0, then only priority tagged (tag 0)
+ * Ethernet frames can be received. In this case we do not need to
+ * allocate any memory for VLAN interfaces.
+ */
+#if CONFIG_NET_VLAN_COUNT > 0
+
 #define MAX_VLAN_NAME_LEN MIN(sizeof("VLAN-<#####>"), \
 			      CONFIG_NET_INTERFACE_NAME_LEN)
 #define MAX_VIRT_NAME_LEN MIN(sizeof("<not attached>"), \
@@ -657,3 +663,27 @@ static void vlan_iface_init(struct net_if *iface)
 
 	ctx->init_done = true;
 }
+
+#else /* CONFIG_NET_VLAN_COUNT > 0 */
+
+/* Dummy functions if VLAN is not really used. This is only needed
+ * if priority tagged frames (tag 0) are supported.
+ */
+bool net_eth_is_vlan_enabled(struct ethernet_context *ctx,
+			     struct net_if *iface)
+{
+	ARG_UNUSED(ctx);
+	ARG_UNUSED(iface);
+
+	return true;
+}
+
+struct net_if *net_eth_get_vlan_iface(struct net_if *iface, uint16_t tag)
+{
+	if (tag == NET_VLAN_TAG_PRIORITY) {
+		return iface;
+	}
+
+	return NULL;
+}
+#endif /* CONFIG_NET_VLAN_COUNT > 0 */

--- a/subsys/net/lib/ptp/ptp.c
+++ b/subsys/net/lib/ptp/ptp.c
@@ -114,3 +114,16 @@ static int ptp_init(void)
 }
 
 SYS_INIT(ptp_init, APPLICATION, CONFIG_PTP_INIT_PRIO);
+
+static enum net_verdict ptp_recv(struct net_if *iface, uint16_t ptype,
+				 struct net_pkt *pkt)
+{
+	ARG_UNUSED(iface);
+	ARG_UNUSED(ptype);
+
+	net_pkt_set_family(pkt, AF_UNSPEC);
+
+	return NET_CONTINUE;
+}
+
+ETH_NET_L3_REGISTER(PTP, NET_ETH_PTYPE_PTP, ptp_recv);

--- a/subsys/net/lib/shell/net_shell_private.h
+++ b/subsys/net/lib/shell/net_shell_private.h
@@ -64,8 +64,12 @@ struct net_shell_user_data {
 #if !defined(NET_VLAN_MAX_COUNT)
 #define MAX_IFACE_COUNT NET_IF_MAX_CONFIGS
 #else
+#if NET_VLAN_MAX_COUNT > 0
 #define MAX_IFACE_COUNT NET_VLAN_MAX_COUNT
-#endif
+#else
+#define MAX_IFACE_COUNT NET_IF_MAX_CONFIGS
+#endif /* NET_VLAN_MAX_COUNT > 0 */
+#endif /* !NET_VLAN_MAX_COUNT */
 
 #if defined(CONFIG_NET_IPV6) && !defined(CONFIG_NET_IPV4)
 #define ADDR_LEN NET_IPV6_ADDR_LEN

--- a/subsys/net/lib/shell/stats.c
+++ b/subsys/net/lib/shell/stats.c
@@ -368,22 +368,24 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 	PR("RX traffic class statistics:\n");
 
 #if defined(CONFIG_NET_PKT_RXTIME_STATS)
-	PR("TC  Priority\tRecv pkts\tbytes\ttime\n");
+	PR("TC  Priority\tRecv pkts\tDrop pkts\tbytes\ttime\n");
 
 	for (i = 0; i < NET_TC_RX_COUNT; i++) {
 		net_stats_t count = GET_STAT(iface,
 					     tc.recv[i].rx_time.count);
 		if (count == 0) {
-			PR("[%d] %s (%d)\t%d\t\t%d\t-\n", i,
+			PR("[%d] %s (%d)\t%d\t%d\t\t%d\t-\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
+			   GET_STAT(iface, tc.recv[i].dropped),
 			   GET_STAT(iface, tc.recv[i].bytes));
 		} else {
-			PR("[%d] %s (%d)\t%d\t\t%d\t%u us%s\n", i,
+			PR("[%d] %s (%d)\t%d\t%d\t\t%d\t%u us%s\n", i,
 			   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 			   GET_STAT(iface, tc.recv[i].priority),
 			   GET_STAT(iface, tc.recv[i].pkts),
+			   GET_STAT(iface, tc.recv[i].dropped),
 			   GET_STAT(iface, tc.recv[i].bytes),
 			   (uint32_t)(GET_STAT(iface,
 					    tc.recv[i].rx_time.sum) /
@@ -392,13 +394,14 @@ static void print_tc_rx_stats(const struct shell *sh, struct net_if *iface)
 		}
 	}
 #else
-	PR("TC  Priority\tRecv pkts\tbytes\n");
+	PR("TC  Priority\tRecv pkts\tDrop pkts\tbytes\n");
 
 	for (i = 0; i < NET_TC_RX_COUNT; i++) {
-		PR("[%d] %s (%d)\t%d\t\t%d\n", i,
+		PR("[%d] %s (%d)\t%d\t%d\t\t%d\n", i,
 		   priority2str(GET_STAT(iface, tc.recv[i].priority)),
 		   GET_STAT(iface, tc.recv[i].priority),
 		   GET_STAT(iface, tc.recv[i].pkts),
+		   GET_STAT(iface, tc.recv[i].dropped),
 		   GET_STAT(iface, tc.recv[i].bytes));
 	}
 #endif /* CONFIG_NET_PKT_RXTIME_STATS */


### PR DESCRIPTION
Upsteam patches:
- linker section for ethernet callbacks, hooking callbacks for ethernet low level api
https://github.com/zephyrproject-rtos/zephyr/pull/84037
- Support VLAN header without actual VLAN interface (priority tagged frames)
https://github.com/zephyrproject-rtos/zephyr/issues/84023
https://github.com/zephyrproject-rtos/zephyr/issues/83662
(initially interpreted as bug: https://github.com/zephyrproject-rtos/zephyr/issues/83277)
- Fix traffic class starvation problem, skip on RX-side
https://github.com/zephyrproject-rtos/zephyr/issues/84524
https://github.com/zephyrproject-rtos/zephyr/issues/84415
- Bugfix: https://github.com/zephyrproject-rtos/zephyr/pull/84870


Non upsteam patches:
- packet priority assignment
- workaround for: https://github.com/zephyrproject-rtos/zephyr/issues/85050

Some change from here was reverted upsteam due to dropping to many outgoing packets (https://github.com/zephyrproject-rtos/zephyr/pull/85868). For 4.1 we will likely need instead https://github.com/zephyrproject-rtos/zephyr/pull/86127 (scheduled to land in 4.2)


If we DO NOT update to 4.1 as soon as possible there are other fixes we will likely need. For example: https://github.com/zephyrproject-rtos/zephyr/pull/85955