### PR TITLE
Feature/backports collection 4.1

### DIFF
--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -729,6 +729,11 @@ static void rx_thread(void *arg1, void *unused1, void *unused2)
 				net_eth_carrier_on(get_iface(dev_data));
 			}
 			while ((pkt = eth_rx(dev)) != NULL) {
+				if (ntohs(NET_ETH_HDR(pkt)->type) == NET_ETH_PTYPE_PNIO) {
+					/* NET_PRIORITY_NC = 7 is Network control (highest priority) */
+					net_pkt_set_priority(pkt, NET_PRIORITY_NC);
+				}
+
 				iface = net_pkt_iface(pkt);
 #if defined(CONFIG_NET_DSA)
 				iface = dsa_net_recv(iface, &pkt);

--- a/drivers/ethernet/phy/phy_mii.c
+++ b/drivers/ethernet/phy/phy_mii.c
@@ -471,11 +471,12 @@ static int phy_mii_initialize(const struct device *dev)
 
 		/* Advertise all speeds */
 		phy_mii_cfg_link(dev, LINK_HALF_10BASE_T |
-				      LINK_FULL_10BASE_T |
+				      LINK_FULL_10BASE_T /* |
 				      LINK_HALF_100BASE_T |
 				      LINK_FULL_100BASE_T |
 				      LINK_HALF_1000BASE_T |
-				      LINK_FULL_1000BASE_T);
+				      LINK_FULL_1000BASE_T */
+				      );
 
 		k_work_init_delayable(&data->monitor_work,
 					monitor_work_handler);

--- a/include/zephyr/net/ethernet.h
+++ b/include/zephyr/net/ethernet.h
@@ -70,6 +70,7 @@ struct net_eth_addr {
 #define NET_ETH_PTYPE_IP		0x0800
 #define NET_ETH_PTYPE_IPV6		0x86dd
 #define NET_ETH_PTYPE_LLDP		0x88cc
+#define NET_ETH_PTYPE_PNIO		0x8892
 #define NET_ETH_PTYPE_PTP		0x88f7
 #define NET_ETH_PTYPE_TSN		0x22f0 /* TSN (IEEE 1722) packet */
 #define NET_ETH_PTYPE_VLAN		0x8100

--- a/include/zephyr/net/net_context.h
+++ b/include/zephyr/net/net_context.h
@@ -1199,7 +1199,7 @@ int net_context_send(struct net_context *context,
  * @param dst_addr Destination address.
  * @param addrlen Length of the address.
  * @param cb Caller-supplied callback function.
- * @param timeout Currently this value is not used.
+ * @param timeout Timeout for the send attempt.
  * @param user_data Caller-supplied user data.
  *
  * @return numbers of bytes sent on success, a negative errno otherwise

--- a/include/zephyr/net/net_core.h
+++ b/include/zephyr/net/net_core.h
@@ -124,18 +124,38 @@ enum net_verdict {
 int net_recv_data(struct net_if *iface, struct net_pkt *pkt);
 
 /**
- * @brief Send data to network.
+ * @brief Try sending data to network.
  *
  * @details Send data to network. This should not be used normally by
  * applications as it requires that the network packet is properly
  * constructed.
  *
  * @param pkt Network packet.
+ * @param timeout Timeout for send.
  *
  * @return 0 if ok, <0 if error. If <0 is returned, then the caller needs
  * to unref the pkt in order to avoid memory leak.
  */
-int net_send_data(struct net_pkt *pkt);
+int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout);
+
+/**
+ * @brief Send data to network.
+ *
+ * @details Send data to network. This should not be used normally by
+ * applications as it requires that the network packet is properly
+ * constructed. Equivalent to net_try_send_data with infinite timeout.
+ *
+ * @param pkt Network packet.
+ *
+ * @return 0 if ok, <0 if error. If <0 is returned, then the caller needs
+ * to unref the pkt in order to avoid memory leak.
+ */
+static inline int net_send_data(struct net_pkt *pkt)
+{
+	k_timeout_t timeout = k_is_in_isr() ? K_NO_WAIT : K_FOREVER;
+
+	return net_try_send_data(pkt, timeout);
+}
 
 /** @cond INTERNAL_HIDDEN */
 

--- a/include/zephyr/net/net_if.h
+++ b/include/zephyr/net/net_if.h
@@ -925,14 +925,33 @@ static inline enum net_if_oper_state net_if_oper_state(struct net_if *iface)
 }
 
 /**
- * @brief Send a packet through a net iface
+ * @brief Try sending a packet through a net iface
  *
  * @param iface Pointer to a network interface structure
  * @param pkt Pointer to a net packet to send
+ * @param timeout timeout for attempting to send
  *
- * return verdict about the packet
+ * @return verdict about the packet
  */
-enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt);
+enum net_verdict net_if_try_send_data(struct net_if *iface,
+				      struct net_pkt *pkt, k_timeout_t timeout);
+
+/**
+ * @brief Send a packet through a net iface
+ *
+ * This is equivalent to net_if_try_queue_tx with an infinite timeout
+ * @param iface Pointer to a network interface structure
+ * @param pkt Pointer to a net packet to send
+ *
+ * @return verdict about the packet
+ */
+static inline enum net_verdict net_if_send_data(struct net_if *iface,
+						struct net_pkt *pkt)
+{
+	k_timeout_t timeout = k_is_in_isr() ? K_NO_WAIT : K_FOREVER;
+
+	return net_if_try_send_data(iface, pkt, timeout);
+}
 
 /**
  * @brief Get a pointer to the interface L2
@@ -993,12 +1012,27 @@ static inline const struct device *net_if_get_device(struct net_if *iface)
 }
 
 /**
- * @brief Queue a packet to the net interface TX queue
+ * @brief Try enqueuing a packet to the net interface TX queue
  *
  * @param iface Pointer to a network interface structure
  * @param pkt Pointer to a net packet to queue
+ * @param timeout Timeout for the enqueuing attempt
  */
-void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt);
+void net_if_try_queue_tx(struct net_if *iface, struct net_pkt *pkt, k_timeout_t timeout);
+
+/**
+ * @brief Queue a packet to the net interface TX queue
+ *
+ * This is equivalent to net_if_try_queue_tx with an infinite timeout
+ * @param iface Pointer to a network interface structure
+ * @param pkt Pointer to a net packet to queue
+ */
+static inline void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
+{
+	k_timeout_t timeout = k_is_in_isr() ? K_NO_WAIT : K_FOREVER;
+
+	net_if_try_queue_tx(iface, pkt, timeout);
+}
 
 /**
  * @brief Return the IP offload status

--- a/subsys/net/ip/icmp.c
+++ b/subsys/net/ip/icmp.c
@@ -207,7 +207,7 @@ static int send_icmpv4_echo_request(struct net_icmp_ctx *ctx,
 	ctx->user_data = user_data;
 	ctx->iface = iface;
 
-	if (net_send_data(pkt) >= 0) {
+	if (net_try_send_data(pkt, K_NO_WAIT) >= 0) {
 		net_stats_update_icmp_sent(iface);
 		return 0;
 	}
@@ -330,7 +330,7 @@ static int send_icmpv6_echo_request(struct net_icmp_ctx *ctx,
 	ctx->user_data = user_data;
 	ctx->iface = iface;
 
-	if (net_send_data(pkt) >= 0) {
+	if (net_try_send_data(pkt, K_NO_WAIT) >= 0) {
 		net_stats_update_icmp_sent(iface);
 		return 0;
 	}

--- a/subsys/net/ip/icmpv4.c
+++ b/subsys/net/ip/icmpv4.c
@@ -493,7 +493,7 @@ static int icmpv4_handle_echo_request(struct net_icmp_ctx *ctx,
 		net_sprint_ipv4_addr(src),
 		net_sprint_ipv4_addr(&ip_hdr->src));
 
-	if (net_send_data(reply) < 0) {
+	if (net_try_send_data(reply, K_NO_WAIT) < 0) {
 		goto drop;
 	}
 
@@ -588,7 +588,7 @@ int net_icmpv4_send_error(struct net_pkt *orig, uint8_t type, uint8_t code)
 		net_sprint_ipv4_addr(&ip_hdr->dst),
 		net_sprint_ipv4_addr(&ip_hdr->src));
 
-	if (net_send_data(pkt) >= 0) {
+	if (net_try_send_data(pkt, K_NO_WAIT) >= 0) {
 		net_stats_update_icmp_sent(net_pkt_iface(orig));
 		return 0;
 	}

--- a/subsys/net/ip/icmpv6.c
+++ b/subsys/net/ip/icmpv6.c
@@ -169,7 +169,7 @@ static int icmpv6_handle_echo_request(struct net_icmp_ctx *ctx,
 		net_sprint_ipv6_addr(src),
 		net_sprint_ipv6_addr(&ip_hdr->src));
 
-	if (net_send_data(reply) < 0) {
+	if (net_try_send_data(reply, K_NO_WAIT) < 0) {
 		goto drop;
 	}
 
@@ -319,7 +319,7 @@ int net_icmpv6_send_error(struct net_pkt *orig, uint8_t type, uint8_t code,
 		net_sprint_ipv6_addr(src),
 		net_sprint_ipv6_addr(&ip_hdr->src));
 
-	if (net_send_data(pkt) >= 0) {
+	if (net_try_send_data(pkt, K_NO_WAIT) >= 0) {
 		net_stats_update_icmp_sent(net_pkt_iface(pkt));
 		return 0;
 	}

--- a/subsys/net/ip/net_context.c
+++ b/subsys/net/ip/net_context.c
@@ -2544,7 +2544,7 @@ skip_alloc:
 
 		context_finalize_packet(context, family, pkt);
 
-		ret = net_send_data(pkt);
+		ret = net_try_send_data(pkt, timeout);
 	} else if (IS_ENABLED(CONFIG_NET_TCP) &&
 		   net_context_get_proto(context) == IPPROTO_TCP) {
 
@@ -2588,7 +2588,7 @@ skip_alloc:
 			}
 
 			/* Pass to L2: */
-			ret = net_send_data(pkt);
+			ret = net_try_send_data(pkt, timeout);
 		} else {
 			struct sockaddr_ll_ptr *ll_src_addr;
 			struct sockaddr_ll *ll_dst_addr;
@@ -2609,7 +2609,7 @@ skip_alloc:
 			net_pkt_set_ll_proto_type(pkt,
 						  ntohs(ll_dst_addr->sll_protocol));
 
-			net_if_queue_tx(net_pkt_iface(pkt), pkt);
+			net_if_try_queue_tx(net_pkt_iface(pkt), pkt, timeout);
 		}
 	} else if (IS_ENABLED(CONFIG_NET_SOCKETS_CAN) && family == AF_CAN &&
 		   net_context_get_proto(context) == CAN_RAW) {
@@ -2620,7 +2620,7 @@ skip_alloc:
 
 		net_pkt_cursor_init(pkt);
 
-		ret = net_send_data(pkt);
+		ret = net_try_send_data(pkt, timeout);
 	} else {
 		NET_DBG("Unknown protocol while sending packet: %d",
 		net_context_get_proto(context));

--- a/subsys/net/ip/net_core.c
+++ b/subsys/net/ip/net_core.c
@@ -363,8 +363,7 @@ drop:
 	return ret;
 }
 
-/* Called when data needs to be sent to network */
-int net_send_data(struct net_pkt *pkt)
+int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout)
 {
 	int status;
 	int ret;
@@ -407,7 +406,7 @@ int net_send_data(struct net_pkt *pkt)
 		goto err;
 	}
 
-	if (net_if_send_data(net_pkt_iface(pkt), pkt) == NET_DROP) {
+	if (net_if_try_send_data(net_pkt_iface(pkt), pkt, timeout) == NET_DROP) {
 		ret = -EIO;
 		goto err;
 	}
@@ -570,9 +569,10 @@ static inline void l3_init(void)
 #else /* CONFIG_NET_NATIVE */
 #define l3_init(...)
 #define net_post_init(...)
-int net_send_data(struct net_pkt *pkt)
+int net_try_send_data(struct net_pkt *pkt, k_timeout_t timeout)
 {
 	ARG_UNUSED(pkt);
+	ARG_UNUSED(timeout);
 
 	return -ENOTSUP;
 }

--- a/subsys/net/ip/net_if.c
+++ b/subsys/net/ip/net_if.c
@@ -342,7 +342,7 @@ void net_process_tx_packet(struct net_pkt *pkt)
 #endif
 }
 
-void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
+void net_if_try_queue_tx(struct net_if *iface, struct net_pkt *pkt, k_timeout_t timeout)
 {
 	if (!net_pkt_filter_send_ok(pkt)) {
 		/* silently drop the packet */
@@ -368,7 +368,7 @@ void net_if_queue_tx(struct net_if *iface, struct net_pkt *pkt)
 
 		net_if_tx(net_pkt_iface(pkt), pkt);
 	} else {
-		if (net_tc_submit_to_tx_queue(tc, pkt) != NET_OK) {
+		if (net_tc_try_submit_to_tx_queue(tc, pkt, timeout) != NET_OK) {
 			goto drop;
 		}
 #if defined(CONFIG_NET_POWER_MANAGEMENT)
@@ -451,7 +451,8 @@ static inline void init_iface(struct net_if *iface)
 }
 
 #if defined(CONFIG_NET_NATIVE)
-enum net_verdict net_if_send_data(struct net_if *iface, struct net_pkt *pkt)
+enum net_verdict net_if_try_send_data(struct net_if *iface, struct net_pkt *pkt,
+				      k_timeout_t timeout)
 {
 	const struct net_l2 *l2;
 	struct net_context *context = net_pkt_context(pkt);
@@ -550,7 +551,7 @@ done:
 		}
 	} else if (verdict == NET_OK) {
 		/* Packet is ready to be sent by L2, let's queue */
-		net_if_queue_tx(iface, pkt);
+		net_if_try_queue_tx(iface, pkt, timeout);
 	}
 
 	return verdict;

--- a/subsys/net/ip/net_private.h
+++ b/subsys/net/ip/net_private.h
@@ -203,7 +203,8 @@ static inline enum net_verdict net_ipv6_input(struct net_pkt *pkt,
 static inline void net_tc_tx_init(void) { }
 static inline void net_tc_rx_init(void) { }
 #endif
-extern enum net_verdict net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt);
+enum net_verdict net_tc_try_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt,
+					       k_timeout_t timeout);
 extern enum net_verdict net_tc_submit_to_rx_queue(uint8_t tc, struct net_pkt *pkt);
 extern enum net_verdict net_promisc_mode_input(struct net_pkt *pkt);
 

--- a/subsys/net/ip/net_tc.c
+++ b/subsys/net/ip/net_tc.c
@@ -65,14 +65,13 @@ static struct net_traffic_class tx_classes[NET_TC_TX_COUNT];
 static struct net_traffic_class rx_classes[NET_TC_RX_COUNT];
 #endif
 
-enum net_verdict net_tc_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt)
+enum net_verdict net_tc_try_submit_to_tx_queue(uint8_t tc, struct net_pkt *pkt,
+					       k_timeout_t timeout)
 {
 #if NET_TC_TX_COUNT > 0
 	net_pkt_set_tx_stats_tick(pkt, k_cycle_get_32());
 
 #if NET_TC_TX_EFFECTIVE_COUNT > 1
-	k_timeout_t timeout = k_is_in_isr() ? K_NO_WAIT : K_FOREVER;
-
 	if (k_sem_take(&tx_classes[tc].fifo_slot, timeout) != 0) {
 		return NET_DROP;
 	}

--- a/subsys/net/l2/ethernet/arp.c
+++ b/subsys/net/l2/ethernet/arp.c
@@ -531,7 +531,10 @@ static void arp_gratuitous_send(struct net_if *iface,
 
 	NET_DBG("Sending gratuitous ARP pkt %p", pkt);
 
-	if (net_if_send_data(iface, pkt) == NET_DROP) {
+	/* send without timeout, so we do not risk being blocked by tx when
+	 * being flooded
+	 */
+	if (net_if_try_send_data(iface, pkt, K_NO_WAIT) == NET_DROP) {
 		net_pkt_unref(pkt);
 	}
 }
@@ -874,7 +877,7 @@ enum net_verdict net_arp_input(struct net_pkt *pkt,
 		/* Send reply */
 		reply = arp_prepare_reply(net_pkt_iface(pkt), pkt, dst_hw_addr);
 		if (reply) {
-			net_if_queue_tx(net_pkt_iface(reply), reply);
+			net_if_try_queue_tx(net_pkt_iface(reply), reply, K_NO_WAIT);
 		} else {
 			NET_DBG("Cannot send ARP reply");
 		}

--- a/subsys/net/l2/ethernet/lldp/lldp.c
+++ b/subsys/net/l2/ethernet/lldp/lldp.c
@@ -147,7 +147,10 @@ static int lldp_send(struct ethernet_lldp *lldp)
 	net_pkt_lladdr_dst(pkt)->addr = (uint8_t *)lldp_multicast_eth_addr.addr;
 	net_pkt_lladdr_dst(pkt)->len = sizeof(struct net_eth_addr);
 
-	if (net_if_send_data(lldp->iface, pkt) == NET_DROP) {
+	/* send without timeout, so we do not risk being blocked by tx when
+	 * being flooded
+	 */
+	if (net_if_try_send_data(lldp->iface, pkt, K_NO_WAIT) == NET_DROP) {
 		net_pkt_unref(pkt);
 		ret = -EIO;
 	}


### PR DESCRIPTION
Upsteam patches:
- Allow for send to not succeed and put timeout for arp and icmp to `K_NO_WAIT` so rx is not blocked by tx for those protocols
  Issue: https://github.com/zephyrproject-rtos/zephyr/issues/85981
  PR: https://github.com/zephyrproject-rtos/zephyr/pull/86127

Non upsteam patches:
- packet priority assignment https://github.com/zephyrproject-rtos/zephyr/issues/84501
- workaround for: https://github.com/zephyrproject-rtos/zephyr/issues/85050
