### PR TITLE
ethernet: stm32_hal: Allow to configure preemtiveness independent of tc

### DIFF
--- a/drivers/ethernet/Kconfig.stm32_hal
+++ b/drivers/ethernet/Kconfig.stm32_hal
@@ -45,6 +45,14 @@ config ETH_STM32_HAL_RX_THREAD_STACK_SIZE
 	help
 	  RX thread stack size
 
+config ETH_STM32_HAL_RX_THREAD_PREEMPTIVE
+	bool "STM32 Ethernet RX Thread pre-emptive [EXPERIMENTAL]"
+	default y if NET_TC_THREAD_PREEMPTIVE
+	depends on PREEMPT_ENABLED
+	select EXPERIMENTAL
+	help
+	  With pre-emptive threads, the thread can be pre-empted.
+
 config ETH_STM32_HAL_RX_THREAD_PRIO
 	int "STM32 Ethernet RX Thread Priority"
 	default 2

--- a/drivers/ethernet/eth_stm32_hal.c
+++ b/drivers/ethernet/eth_stm32_hal.c
@@ -1163,7 +1163,7 @@ static void eth_iface_init(struct net_if *iface)
 		k_thread_create(&dev_data->rx_thread, dev_data->rx_thread_stack,
 				K_KERNEL_STACK_SIZEOF(dev_data->rx_thread_stack),
 				rx_thread, (void *) dev, NULL, NULL,
-				IS_ENABLED(CONFIG_NET_TC_THREAD_PREEMPTIVE)
+				IS_ENABLED(CONFIG_ETH_STM32_HAL_RX_THREAD_PREEMPTIVE)
 					? K_PRIO_PREEMPT(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO)
 					: K_PRIO_COOP(CONFIG_ETH_STM32_HAL_RX_THREAD_PRIO),
 				0, K_NO_WAIT);


### PR DESCRIPTION
Allow to configure the preemtiveness of the ethernet rx-thread independent of the traffic-class queue.

Upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/87116