### PR TITLE
net: http: Add compression support in HTTP server

### DIFF
--- a/include/zephyr/net/http/server.h
+++ b/include/zephyr/net/http/server.h
@@ -138,6 +138,16 @@ struct http_resource_detail_static_fs {
 	const char *fs_path;
 };
 
+/** @brief HTTP compressions */
+enum http_compression {
+	HTTP_NONE = 0,     /**< NONE */
+	HTTP_GZIP = 1,     /**< GZIP */
+	HTTP_COMPRESS = 2, /**< COMPRESS */
+	HTTP_DEFLATE = 3,  /**< DEFLATE */
+	HTTP_BR = 4,       /**< BR */
+	HTTP_ZSTD = 5      /**< ZSTD */
+};
+
 /** @cond INTERNAL_HIDDEN */
 /* Make sure that the common is the first in the struct. */
 BUILD_ASSERT(offsetof(struct http_resource_detail_static_fs, common) == 0);
@@ -475,6 +485,11 @@ struct http_client_ctx {
 	IF_ENABLED(CONFIG_WEBSOCKET, (uint8_t ws_sec_key[HTTP_SERVER_WS_MAX_SEC_KEY_LEN]));
 /** @endcond */
 
+/** @cond INTERNAL_HIDDEN */
+	/** Client supported compression. */
+	IF_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION, (uint8_t supported_compression));
+/** @endcond */
+
 	/** Flag indicating that HTTP2 preface was sent. */
 	bool preface_sent : 1;
 
@@ -492,6 +507,9 @@ struct http_client_ctx {
 
 	/** Flag indicating Websocket key is being processed. */
 	bool websocket_sec_key_next : 1;
+
+	/** Flag indicating accept encoding is being processed. */
+	IF_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION, (bool accept_encoding_next: 1));
 
 	/** The next frame on the stream is expectd to be a continuation frame. */
 	bool expect_continuation : 1;

--- a/subsys/net/lib/http/CMakeLists.txt
+++ b/subsys/net/lib/http/CMakeLists.txt
@@ -16,6 +16,7 @@ zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER http_server_core.c
 						http_server_http2.c
 						http_hpack.c
 						http_huffman.c)
+zephyr_library_sources_ifdef(CONFIG_HTTP_SERVER_COMPRESSION http_compression.c)
 if(CONFIG_HTTP_SERVER AND CONFIG_WEBSOCKET)
   zephyr_library_sources(http_server_ws.c)
   zephyr_library_link_libraries_ifdef(CONFIG_MBEDTLS mbedTLS)

--- a/subsys/net/lib/http/Kconfig
+++ b/subsys/net/lib/http/Kconfig
@@ -29,7 +29,7 @@ config HTTP_CLIENT
 	help
 	  HTTP client API
 
-config HTTP_SERVER
+menuconfig HTTP_SERVER
 	bool "HTTP Server [EXPERIMENTAL]"
 	select HTTP_PARSER
 	select HTTP_PARSER_URL
@@ -201,6 +201,21 @@ config WEBSOCKET_CONSOLE
 	help
 	  Hidden option that is enabled only when all the necessary options
 	  needed by websocket console are set.
+
+config HTTP_SERVER_COMPRESSION
+	bool "Compression support in HTTP fileserver"
+	help
+	  If enabled, the fileserver will parse the accept-encoding header
+	  from the client and extract the supported compression methods.
+	  Afterwards it will try to serve the first compressed file available
+	  by using the file ending as compression indicator in this order:
+	    1. brotli   -> .br
+	    2. gzip     -> .gz
+	    3. zstd     -> .zst
+	    4. compress -> .lzw
+	    5. deflate  -> .zz
+	    6. File without compression
+
 endif
 
 # Hidden option to avoid having multiple individual options that are ORed together

--- a/subsys/net/lib/http/headers/server_internal.h
+++ b/subsys/net/lib/http/headers/server_internal.h
@@ -36,20 +36,28 @@ int enter_http1_request(struct http_client_ctx *client);
 int enter_http2_request(struct http_client_ctx *client);
 int enter_http_done_state(struct http_client_ctx *client);
 
+/* HTTP Compression handling */
+#define HTTP_COMPRESSION_MAX_STRING_LEN 8
+void http_compression_parse_accept_encoding(const char *accept_encoding, size_t len,
+					    uint8_t *supported_compression);
+const char *http_compression_text(enum http_compression compression);
+int http_compression_from_text(enum http_compression *compression, const char *text);
+bool compression_value_is_valid(enum http_compression compression);
+
 /* Others */
 struct http_resource_detail *get_resource_detail(const struct http_service_desc *service,
 						 const char *path, int *len, bool is_ws);
 int http_server_sendall(struct http_client_ctx *client, const void *buf, size_t len);
 void http_server_get_content_type_from_extension(char *url, char *content_type,
 						 size_t content_type_size);
-int http_server_find_file(char *fname, size_t fname_size, size_t *file_size, bool *gzipped);
+int http_server_find_file(char *fname, size_t fname_size, size_t *file_size,
+			  uint8_t supported_compression, enum http_compression *chosen_compression);
 void http_client_timer_restart(struct http_client_ctx *client);
 bool http_response_is_final(struct http_response_ctx *rsp, enum http_data_status status);
 bool http_response_is_provided(struct http_response_ctx *rsp);
 
 /* TODO Could be static, but currently used in tests. */
-int parse_http_frame_header(struct http_client_ctx *client, const uint8_t *buffer,
-			    size_t buflen);
+int parse_http_frame_header(struct http_client_ctx *client, const uint8_t *buffer, size_t buflen);
 const char *get_frame_type_name(enum http2_frame_type type);
 
 void populate_request_ctx(struct http_request_ctx *req_ctx, uint8_t *data, size_t len,

--- a/subsys/net/lib/http/http_compression.c
+++ b/subsys/net/lib/http/http_compression.c
@@ -1,0 +1,133 @@
+/** @file
+ * @brief HTTP compression handling functions
+ *
+ * Helper functions to handle compression formats
+ */
+
+/*
+ * Copyright (c) 2025 Endress+Hauser
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ */
+#include <stdbool.h>
+#include <string.h>
+#include <strings.h>
+
+#include <zephyr/net/http/server.h>
+#include <zephyr/sys/__assert.h>
+#include <zephyr/sys/util.h>
+
+#include "headers/server_internal.h"
+
+static int http_compression_match(enum http_compression *compression, const char *text,
+				  enum http_compression expected);
+
+void http_compression_parse_accept_encoding(const char *accept_encoding, size_t len,
+					    uint8_t *supported_compression)
+{
+	enum http_compression detected_compression;
+	char strbuf[HTTP_COMPRESSION_MAX_STRING_LEN + 1] = {0};
+	const char *start = accept_encoding;
+	const char *end = NULL;
+	bool priority_string = false;
+
+	*supported_compression = HTTP_NONE;
+	for (size_t i = 0; i < len; i++) {
+		if (accept_encoding[i] == 0) {
+			break;
+		} else if (accept_encoding[i] == ' ') {
+			start = &accept_encoding[i + 1];
+			continue;
+		} else if (accept_encoding[i] == ';') {
+			end = &accept_encoding[i];
+			priority_string = true;
+		} else if (accept_encoding[i] == ',') {
+			if (!priority_string) {
+				end = &accept_encoding[i];
+			}
+			priority_string = false;
+		} else if (i + 1 == len) {
+			end = &accept_encoding[i + 1];
+		}
+
+		if (end == NULL) {
+			continue;
+		}
+
+		if (end - start > HTTP_COMPRESSION_MAX_STRING_LEN) {
+			end = NULL;
+			start = end + 1;
+			continue;
+		}
+
+		memcpy(strbuf, start, end - start);
+		strbuf[end - start] = 0;
+
+		if (http_compression_from_text(&detected_compression, strbuf) == 0) {
+			WRITE_BIT(*supported_compression, detected_compression, true);
+		}
+
+		end = NULL;
+		start = end + 1;
+	}
+}
+
+const char *http_compression_text(enum http_compression compression)
+{
+	switch (compression) {
+	case HTTP_NONE:
+		return "";
+	case HTTP_GZIP:
+		return "gzip";
+	case HTTP_COMPRESS:
+		return "compress";
+	case HTTP_DEFLATE:
+		return "deflate";
+	case HTTP_BR:
+		return "br";
+	case HTTP_ZSTD:
+		return "zstd";
+	}
+	return "";
+}
+
+int http_compression_from_text(enum http_compression *compression, const char *text)
+{
+	__ASSERT_NO_MSG(compression);
+	__ASSERT_NO_MSG(text);
+
+	for (enum http_compression i = 0; compression_value_is_valid(i); ++i) {
+		if (http_compression_match(compression, text, i) == 0) {
+			return 0;
+		}
+	}
+	return 1;
+}
+
+bool compression_value_is_valid(enum http_compression compression)
+{
+	switch (compression) {
+	case HTTP_NONE:
+	case HTTP_GZIP:
+	case HTTP_COMPRESS:
+	case HTTP_DEFLATE:
+	case HTTP_BR:
+	case HTTP_ZSTD:
+		return true;
+	}
+	return false;
+}
+
+static int http_compression_match(enum http_compression *compression, const char *text,
+				  enum http_compression expected)
+{
+	__ASSERT_NO_MSG(compression);
+	__ASSERT_NO_MSG(text);
+
+	if (strcasecmp(http_compression_text(expected), text) == 0) {
+		*compression = expected;
+		return 0;
+	} else {
+		return 1;
+	}
+}

--- a/subsys/net/lib/http/http_server_core.c
+++ b/subsys/net/lib/http/http_server_core.c
@@ -22,6 +22,7 @@
 #include <zephyr/net/tls_credentials.h>
 #include <zephyr/posix/sys/eventfd.h>
 #include <zephyr/posix/fnmatch.h>
+#include <zephyr/sys/util_macro.h>
 
 LOG_MODULE_REGISTER(net_http_server, CONFIG_NET_HTTP_SERVER_LOG_LEVEL);
 
@@ -785,26 +786,65 @@ struct http_resource_detail *get_resource_detail(const struct http_service_desc 
 	return NULL;
 }
 
-int http_server_find_file(char *fname, size_t fname_size, size_t *file_size, bool *gzipped)
+int http_server_find_file(char *fname, size_t fname_size, size_t *file_size,
+			  uint8_t supported_compression, enum http_compression *chosen_compression)
 {
 	struct fs_dirent dirent;
 	size_t len;
 	int ret;
 
+	len = strlen(fname);
+	if (IS_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION)) {
+		*chosen_compression = HTTP_NONE;
+		if (IS_BIT_SET(supported_compression, HTTP_BR)) {
+			snprintk(fname + len, fname_size - len, ".br");
+			ret = fs_stat(fname, &dirent);
+			if (ret == 0) {
+				*chosen_compression = HTTP_BR;
+				goto return_filename;
+			}
+		}
+		if (IS_BIT_SET(supported_compression, HTTP_GZIP)) {
+			snprintk(fname + len, fname_size - len, ".gz");
+			ret = fs_stat(fname, &dirent);
+			if (ret == 0) {
+				*chosen_compression = HTTP_GZIP;
+				goto return_filename;
+			}
+		}
+		if (IS_BIT_SET(supported_compression, HTTP_ZSTD)) {
+			snprintk(fname + len, fname_size - len, ".zst");
+			ret = fs_stat(fname, &dirent);
+			if (ret == 0) {
+				*chosen_compression = HTTP_ZSTD;
+				goto return_filename;
+			}
+		}
+		if (IS_BIT_SET(supported_compression, HTTP_COMPRESS)) {
+			snprintk(fname + len, fname_size - len, ".lzw");
+			ret = fs_stat(fname, &dirent);
+			if (ret == 0) {
+				*chosen_compression = HTTP_COMPRESS;
+				goto return_filename;
+			}
+		}
+		if (IS_BIT_SET(supported_compression, HTTP_DEFLATE)) {
+			snprintk(fname + len, fname_size - len, ".zz");
+			ret = fs_stat(fname, &dirent);
+			if (ret == 0) {
+				*chosen_compression = HTTP_DEFLATE;
+				goto return_filename;
+			}
+		}
+	}
 	ret = fs_stat(fname, &dirent);
-	if (ret < 0) {
-		len = strlen(fname);
-		snprintk(fname + len, fname_size - len, ".gz");
-		ret = fs_stat(fname, &dirent);
-		*gzipped = (ret == 0);
+	if (ret != 0) {
+		return -ENOENT;
 	}
 
-	if (ret == 0) {
-		*file_size = dirent.size;
-		return ret;
-	}
-
-	return -ENOENT;
+return_filename:
+	*file_size = dirent.size;
+	return ret;
 }
 
 void http_server_get_content_type_from_extension(char *url, char *content_type,

--- a/subsys/net/lib/http/http_server_http1.c
+++ b/subsys/net/lib/http/http_server_http1.c
@@ -19,6 +19,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/http/service.h>
+#include <zephyr/net/http/server.h>
 
 LOG_MODULE_DECLARE(net_http_server, CONFIG_NET_HTTP_SERVER_LOG_LEVEL);
 
@@ -468,13 +469,26 @@ static int dynamic_post_put_req(struct http_resource_detail_dynamic *dynamic_det
 int handle_http1_static_fs_resource(struct http_resource_detail_static_fs *static_fs_detail,
 				    struct http_client_ctx *client)
 {
-#define RESPONSE_TEMPLATE_STATIC_FS				\
-	"HTTP/1.1 200 OK\r\n"					\
-	"Content-Length: %zd\r\n"				\
-	"Content-Type: %s%s\r\n\r\n"
-#define CONTENT_ENCODING_GZIP "\r\nContent-Encoding: gzip"
+#define RESPONSE_TEMPLATE_STATIC_FS                                                                \
+	"HTTP/1.1 200 OK\r\n"                                                                      \
+	"Content-Length: %zd\r\n"                                                                  \
+	"Content-Type: %s%s%s\r\n\r\n"
+#define CONTENT_ENCODING_HEADER "\r\nContent-Encoding: "
+/* Add couple of bytes to response template size to have space
+ * for the content type and encoding
+ */
+#define STATIC_FS_RESPONSE_BASE_SIZE                                                               \
+	sizeof(RESPONSE_TEMPLATE_STATIC_FS) + HTTP_SERVER_MAX_CONTENT_TYPE_LEN +                   \
+		sizeof("Content-Length: 01234567890123456789\r\n")
+#define CONTENT_ENCODING_HEADER_SIZE                                                               \
+	sizeof(CONTENT_ENCODING_HEADER) + HTTP_COMPRESSION_MAX_STRING_LEN + sizeof("\r\n")
+#define STATIC_FS_RESPONSE_SIZE                                                                    \
+	COND_CODE_1(                                                                               \
+		IS_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION),                                        \
+		(STATIC_FS_RESPONSE_BASE_SIZE + CONTENT_ENCODING_HEADER_SIZE),                     \
+		(STATIC_FS_RESPONSE_BASE_SIZE))
 
-	bool gzipped = false;
+	enum http_compression chosen_compression = 0;
 	int len;
 	int remaining;
 	int ret;
@@ -482,12 +496,7 @@ int handle_http1_static_fs_resource(struct http_resource_detail_static_fs *stati
 	struct fs_file_t file;
 	char fname[HTTP_SERVER_MAX_URL_LENGTH];
 	char content_type[HTTP_SERVER_MAX_CONTENT_TYPE_LEN] = "text/html";
-	/* Add couple of bytes to response template size to have space
-	 * for the content type and encoding
-	 */
-	char http_response[sizeof(RESPONSE_TEMPLATE_STATIC_FS) + HTTP_SERVER_MAX_CONTENT_TYPE_LEN +
-			   sizeof("Content-Length: 01234567890123456789\r\n") +
-			   sizeof(CONTENT_ENCODING_GZIP)];
+	char http_response[STATIC_FS_RESPONSE_SIZE];
 
 	if (client->method != HTTP_GET) {
 		return send_http1_405(client);
@@ -506,7 +515,12 @@ int handle_http1_static_fs_resource(struct http_resource_detail_static_fs *stati
 	}
 
 	/* open file, if it exists */
-	ret = http_server_find_file(fname, sizeof(fname), &file_size, &gzipped);
+#ifdef CONFIG_HTTP_SERVER_COMPRESSION
+	ret = http_server_find_file(fname, sizeof(fname), &file_size, client->supported_compression,
+			    &chosen_compression);
+#else
+	ret = http_server_find_file(fname, sizeof(fname), &file_size, 0, NULL);
+#endif /* CONFIG_HTTP_SERVER_COMPRESSION */
 	if (ret < 0) {
 		LOG_ERR("fs_stat %s: %d", fname, ret);
 		return send_http1_404(client);
@@ -523,8 +537,15 @@ int handle_http1_static_fs_resource(struct http_resource_detail_static_fs *stati
 	LOG_DBG("found %s, file size: %zu", fname, file_size);
 
 	/* send HTTP header */
-	len = snprintk(http_response, sizeof(http_response), RESPONSE_TEMPLATE_STATIC_FS,
-		       file_size, content_type, gzipped ? CONTENT_ENCODING_GZIP : "");
+	if (IS_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION) &&
+	    http_compression_text(chosen_compression)[0] != 0) {
+		len = snprintk(http_response, sizeof(http_response), RESPONSE_TEMPLATE_STATIC_FS,
+			       file_size, content_type, CONTENT_ENCODING_HEADER,
+			       http_compression_text(chosen_compression));
+	} else {
+		len = snprintk(http_response, sizeof(http_response), RESPONSE_TEMPLATE_STATIC_FS,
+			       file_size, content_type, "", "");
+	}
 	ret = http_server_sendall(client, http_response, len);
 	if (ret < 0) {
 		goto close;
@@ -698,6 +719,11 @@ static int on_header_field(struct http_parser *parser, const char *at,
 			} else if (strcasecmp(ctx->header_buffer, "Sec-WebSocket-Key") == 0) {
 				ctx->websocket_sec_key_next = true;
 			}
+#ifdef CONFIG_HTTP_SERVER_COMPRESSION
+			else if (strcasecmp(ctx->header_buffer, "Accept-Encoding") == 0) {
+				ctx->accept_encoding_next = true;
+			}
+#endif /* CONFIG_HTTP_SERVER_COMPRESSION */
 
 			ctx->header_buffer[0] = '\0';
 		}
@@ -783,6 +809,13 @@ static int on_header_value(struct http_parser *parser,
 #endif
 				ctx->websocket_sec_key_next = false;
 			}
+#ifdef CONFIG_HTTP_SERVER_COMPRESSION
+			if (ctx->accept_encoding_next) {
+				http_compression_parse_accept_encoding(ctx->header_buffer, offset,
+								       &ctx->supported_compression);
+				ctx->accept_encoding_next = false;
+			}
+#endif /* CONFIG_HTTP_SERVER_COMPRESSION */
 
 			ctx->header_buffer[0] = '\0';
 		}

--- a/subsys/net/lib/http/http_server_http2.c
+++ b/subsys/net/lib/http/http_server_http2.c
@@ -17,6 +17,7 @@
 #include <zephyr/kernel.h>
 #include <zephyr/logging/log.h>
 #include <zephyr/net/http/service.h>
+#include <zephyr/net/http/server.h>
 
 LOG_MODULE_DECLARE(net_http_server, CONFIG_NET_HTTP_SERVER_LOG_LEVEL);
 
@@ -464,7 +465,7 @@ static int handle_http2_static_fs_resource(struct http_resource_detail_static_fs
 		.path_len = static_fs_detail->common.path_len,
 		.type = static_fs_detail->common.type,
 	};
-	bool gzipped;
+	enum http_compression chosen_compression = 0;
 	int len;
 	int remaining;
 	char tmp[64];
@@ -490,7 +491,12 @@ static int handle_http2_static_fs_resource(struct http_resource_detail_static_fs
 	}
 
 	/* open file, if it exists */
-	ret = http_server_find_file(fname, sizeof(fname), &client->data_len, &gzipped);
+#ifdef CONFIG_HTTP_SERVER_COMPRESSION
+	ret = http_server_find_file(fname, sizeof(fname), &client->data_len,
+					client->supported_compression, &chosen_compression);
+#else
+	ret = http_server_find_file(fname, sizeof(fname), &client->data_len, 0, NULL);
+#endif /* CONFIG_HTTP_SERVER_COMPRESSION */
 	if (ret < 0) {
 		LOG_ERR("fs_stat %s: %d", fname, ret);
 
@@ -511,8 +517,8 @@ static int handle_http2_static_fs_resource(struct http_resource_detail_static_fs
 	}
 
 	/* send headers */
-	if (gzipped) {
-		res_detail.content_encoding = "gzip";
+	if (IS_ENABLED(CONFIG_HTTP_SERVER_COMPRESSION)) {
+		res_detail.content_encoding = http_compression_text(chosen_compression);
 	}
 	ret = send_headers_frame(client, HTTP_200_OK, frame->stream_identifier, &res_detail, 0,
 				 NULL, 0);
@@ -1387,7 +1393,15 @@ static int process_header(struct http_client_ctx *client,
 		}
 
 		client->content_len = (size_t)len;
-	} else {
+	}
+#ifdef CONFIG_HTTP_SERVER_COMPRESSION
+	else if (header->name_len == (sizeof("accept-encoding") - 1) &&
+		 memcmp(header->name, "accept-encoding", header->name_len) == 0) {
+		http_compression_parse_accept_encoding(header->value, header->value_len,
+						       &client->supported_compression);
+	}
+#endif /* CONFIG_HTTP_SERVER_COMPRESSION */
+	else {
 		/* Just ignore for now. */
 		LOG_DBG("Ignoring field %.*s", (int)header->name_len, header->name);
 	}


### PR DESCRIPTION
Add compression support using the accept-encoding
header to the http server static filesystem resource.