### PR TITLE
boards: st: stm32h573i_dk: Add support for probe-rs

### DIFF
--- a/boards/st/stm32h573i_dk/board.cmake
+++ b/boards/st/stm32h573i_dk/board.cmake
@@ -10,6 +10,8 @@ endif()
 
 board_runner_args(pyocd "--target=stm32h573iikx")
 
+board_runner_args(probe_rs "--chip=STM32H573II")
+
 board_runner_args(openocd "--tcl-port=6666")
 board_runner_args(openocd --cmd-pre-init "gdb_report_data_abort enable")
 board_runner_args(openocd "--no-halt")
@@ -17,5 +19,6 @@ board_runner_args(openocd "--no-halt")
 # keep first
 include(${ZEPHYR_BASE}/boards/common/stm32cubeprogrammer.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/pyocd.board.cmake)
+include(${ZEPHYR_BASE}/boards/common/probe-rs.board.cmake)
 include(${ZEPHYR_BASE}/boards/common/openocd.board.cmake)
 # FIXME: official openocd runner not yet available.


### PR DESCRIPTION
Allow flashing the STM32H573II chip found on the STM32H573I-DK board using the probe-rs runner.

Backport of upstream PR: https://github.com/zephyrproject-rtos/zephyr/pull/87990