### PR TITLE
net: sockets: Enable gethostname even if socket-offloading is selected

### DIFF
--- a/subsys/net/lib/sockets/CMakeLists.txt
+++ b/subsys/net/lib/sockets/CMakeLists.txt
@@ -9,12 +9,12 @@ zephyr_library_include_directories(.)
 zephyr_library_sources(
   getaddrinfo.c
   sockets.c
+  sockets_misc.c
 )
 
 if(NOT CONFIG_NET_SOCKETS_OFFLOAD)
 zephyr_library_sources(
   getnameinfo.c
-  sockets_misc.c
   )
 endif()
 


### PR DESCRIPTION
Also allow `gethostname` to be compiled in, even when the socket offloading option is selected.