### PR TITLE
Backport PR 91764

### DIFF
--- a/include/zephyr/shell/shell.h
+++ b/include/zephyr/shell/shell.h
@@ -432,7 +432,7 @@ struct shell_static_entry {
  * @brief Define ending subcommands set.
  *
  */
-#define SHELL_SUBCMD_SET_END {NULL}
+#define SHELL_SUBCMD_SET_END {0}
 
 /**
  * @brief Macro for creating a dynamic entry.


### PR DESCRIPTION
Fix `-Wmissing-field-initializers` warning for SHELL_SUBCMD_SET_END

https://github.com/zephyrproject-rtos/zephyr/pull/91764