### PR TITLE
include: cbprintf: Fix call to memcpy with null pointer

### DIFF
--- a/include/zephyr/sys/cbprintf.h
+++ b/include/zephyr/sys/cbprintf.h
@@ -529,6 +529,10 @@ static inline int z_cbprintf_cpy(const void *buf, size_t len, void *ctx)
 {
 	struct z_cbprintf_buf_desc *desc = (struct z_cbprintf_buf_desc *)ctx;
 
+	if (len == 0) {
+		return 0;
+	}
+
 	if ((desc->size - desc->off) < len) {
 		return -ENOSPC;
 	}


### PR DESCRIPTION
cbprintf_package_convert may invoke z_cbprintf_cpy with a null pointer to buf and zero length to indicate a flush operation. This triggers an error from the undefined behavior sanitizer due to memcpy being called with a null src, which is undefined behavior according to the C standard.

This is avoided by exiting early in z_cbprintf_cpy when length is zero.