### PR TITLE
drivers: mdio: shell: Fix argument count

### DIFF
--- a/drivers/mdio/mdio_shell.c
+++ b/drivers/mdio/mdio_shell.c
@@ -32,8 +32,13 @@ static void device_name_get(size_t idx, struct shell_static_entry *entry)
 
 SHELL_DYNAMIC_CMD_CREATE(dsub_device_name, device_name_get);
 
-static int parse_device_arg(const struct shell *sh, char **argv, const struct device **dev)
+static int parse_device_arg(const struct shell *sh, size_t argc,
+			    char **argv, const struct device **dev)
 {
+	if (argc < 2) {
+		shell_error(sh, "not enough arguments");
+		return -EINVAL;
+	}
 	*dev = shell_device_get_binding(argv[1]);
 	if (!*dev) {
 		shell_error(sh, "device %s not found", argv[1]);
@@ -55,12 +60,12 @@ static int cmd_mdio_scan(const struct shell *sh, size_t argc, char **argv)
 	uint16_t reg_addr;
 	int ret;
 
-	ret = parse_device_arg(sh, argv, &dev);
+	ret = parse_device_arg(sh, argc, argv, &dev);
 	if (ret < 0) {
 		return ret;
 	}
 
-	if (argc >= 2) {
+	if (argc >= 3) {
 		reg_addr = strtol(argv[2], NULL, 16);
 	} else {
 		reg_addr = 0;
@@ -98,7 +103,7 @@ static int cmd_mdio_write(const struct shell *sh, size_t argc, char **argv)
 	uint16_t port_addr;
 	int ret;
 
-	ret = parse_device_arg(sh, argv, &dev);
+	ret = parse_device_arg(sh, argc, argv, &dev);
 	if (ret < 0) {
 		return ret;
 	}
@@ -130,7 +135,7 @@ static int cmd_mdio_read(const struct shell *sh, size_t argc, char **argv)
 	uint16_t port_addr;
 	int ret;
 
-	ret = parse_device_arg(sh, argv, &dev);
+	ret = parse_device_arg(sh, argc, argv, &dev);
 	if (ret < 0) {
 		return ret;
 	}
@@ -164,7 +169,7 @@ static int cmd_mdio_write_45(const struct shell *sh, size_t argc, char **argv)
 	uint8_t port_addr;
 	int ret;
 
-	ret = parse_device_arg(sh, argv, &dev);
+	ret = parse_device_arg(sh, argc, argv, &dev);
 	if (ret < 0) {
 		return ret;
 	}
@@ -198,7 +203,7 @@ static int cmd_mdio_read_c45(const struct shell *sh, size_t argc, char **argv)
 	uint8_t port_addr;
 	int ret;
 
-	ret = parse_device_arg(sh, argv, &dev);
+	ret = parse_device_arg(sh, argc, argv, &dev);
 	if (ret < 0) {
 		return ret;
 	}
@@ -226,7 +231,7 @@ static int cmd_mdio_read_c45(const struct shell *sh, size_t argc, char **argv)
 SHELL_STATIC_SUBCMD_SET_CREATE(sub_mdio_cmds,
 	SHELL_CMD_ARG(scan, &dsub_device_name,
 		"Scan MDIO bus for devices: scan <device> [<reg_addr>]",
-		cmd_mdio_scan, 1, 1),
+		cmd_mdio_scan, 2, 1),
 	SHELL_CMD_ARG(read, &dsub_device_name,
 		"Read from MDIO device: read <device> <phy_addr> <reg_addr>",
 		cmd_mdio_read, 4, 0),


### PR DESCRIPTION
Need to have correct argument count to avoid crash.

See: https://github.com/zephyrproject-rtos/zephyr/pull/93257